### PR TITLE
docs: update README and SKILL with current codebase state

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,78 +1,137 @@
 ---
 name: physicclaw-vea
-description: Control the PhysicClaw-VEA interactive 3D visualization application by sending commands to its Zustand store via a local control file. Use this skill to start the application and modify its internal state (mood, thinking, intensity, etc.).
+description: Control the PhysicClaw-VEA interactive 3D visualization application by sending commands to its Zustand store. Supports two control mechanisms: writing to the openclaw-control.json file, or sending HTTP POST requests to the /api/control endpoint. Use this skill to start the application and modify its internal state (mood, thinking, intensity, character, etc.).
 ---
 
 # PhysicClaw-VEA Control Skill
 
-This skill allows OpenClaw to interact with the running instance of the `PhysicClaw-VEA` application by writing commands to the `openclaw-control.json` file in the project root. The `PhysicClaw-VEA` application must be running (e.g., via `npm run dev`) for these commands to take effect.
+This skill allows Claude (or any external agent) to interact with a running instance of the `PhysicClaw-VEA` application.
 
-## Commands
+The application must be running (`npm run dev`) for commands to take effect.
 
-### 1. Start PhysicClaw-VEA in development mode
+---
 
-To start the application, navigate to the `PhysicClaw-VEA` project directory and run the development server.
+## Starting the Application
 
 ```bash
 cd PhysicClaw-VEA
 npm run dev
 ```
 
-### 2. Control the Soul Store
+The dev server listens on `http://localhost:5173` by default.
 
-Use the `control_soul_store` function to send commands to the `PhysicClaw-VEA`'s Zustand store.
+---
 
-```python
-# To set the mood:
-default_api.write(
-    file_path="PhysicClaw-VEA/openclaw-control.json",
-    content='''{ "command": "setMood", "value": "excited", "id": "<timestamp_or_uuid>" }'''
-)
+## Control Mechanisms
 
-# To set thinking state:
-default_api.write(
-    file_path="PhysicClaw-VEA/openclaw-control.json",
-    content='''{ "command": "setIsThinking", "value": true, "id": "<timestamp_or_uuid>" }'''
-)
+There are two ways to send commands. Both are equivalent.
 
-# To set intensity:
-default_api.write(
-    file_path="PhysicClaw-VEA/openclaw-control.json",
-    content='''{ "command": "setIntensity", "value": 0.8, "id": "<timestamp_or_uuid>" }'''
-)
+### Method 1 — HTTP POST to `/api/control` (recommended)
 
-# To set the last message:
-default_api.write(
-    file_path="PhysicClaw-VEA/openclaw-control.json",
-    content='''{ "command": "setLastMessage", "value": "Hello OpenClaw!", "id": "<timestamp_or_uuid>" }'''
-)
+The Vite dev server exposes a `POST /api/control` endpoint. Send a JSON body with `command`, `value`, and a unique `id`.
 
-# To set active character ID:
-default_api.write(
-    file_path="PhysicClaw-VEA/openclaw-control.json",
-    content='''{ "command": "setActiveCharacterId", "value": "listening", "id": "<timestamp_or_uuid>" }'''
-)
+```bash
+curl -X POST http://localhost:5173/api/control \
+  -H "Content-Type: application/json" \
+  -d '{"command": "setMood", "value": "excited", "id": "1"}'
 ```
 
-**Note:** Always include a unique `id` (e.g., a timestamp or UUID) with each command to ensure the application processes new commands and ignores stale ones.
+```python
+import requests, time
 
-## Example Usage
-
-### Start application and make the entity excited
-
-1.  Navigate to the `PhysicClaw-VEA` directory:
-    ```bash
-    cd PhysicClaw-VEA
-    ```
-2.  Start the development server (this will run in the background):
-    ```bash
-    npm run dev &
-    ```
-3.  Send a command to set the mood:
-    ```python
-    import time
-    default_api.write(
-        file_path="PhysicClaw-VEA/openclaw-control.json",
-        content=f'''{{ "command": "setMood", "value": "excited", "id": "{int(time.time())}" }}'''
+def send_command(command: str, value):
+    requests.post(
+        "http://localhost:5173/api/control",
+        json={"command": command, "value": value, "id": str(int(time.time()))},
     )
-    ```
+
+send_command("setMood", "excited")
+send_command("setIsThinking", True)
+send_command("setIntensity", 0.8)
+send_command("setLastMessage", "Hello from Claude!")
+send_command("setActiveCharacterId", "base-sphere")
+```
+
+### Method 2 — Write to `openclaw-control.json`
+
+Write a JSON object to the `openclaw-control.json` file in the project root. The Vite plugin watches for changes and broadcasts the command via HMR.
+
+```python
+import json, time
+
+def send_command(command: str, value):
+    with open("PhysicClaw-VEA/openclaw-control.json", "w") as f:
+        json.dump({"command": command, "value": value, "id": str(int(time.time()))}, f)
+
+send_command("setMood", "excited")
+```
+
+> **Important:** Always include a unique `id` (e.g., a Unix timestamp) with each command. The plugin and the `OpenClawControl` component both use this `id` to avoid re-processing stale commands.
+
+---
+
+## Available Commands
+
+| Command | Value type | Description |
+|---------|-----------|-------------|
+| `setMood` | `string` | Set the entity mood. Values: `'calm'`, `'excited'`, `'thinking'`, `'listening'` |
+| `setIsThinking` | `boolean` | Toggle thinking animation and intensity boost (+0.8) |
+| `setIntensity` | `number` | Set shader energy intensity (range: 0 to ~2, default: 0.5) |
+| `setLastMessage` | `string` | Set the last message displayed in the chat UI |
+| `setActiveCharacterId` | `string` | Switch the active 3D character. Values: `'happy-idle'`, `'base-sphere'` |
+
+---
+
+## Available Characters
+
+| ID | Name | Description |
+|----|------|-------------|
+| `happy-idle` | Happy Bot | Animated FBX character (`/HappyIdle.fbx`), Mixamo rig |
+| `base-sphere` | Energy Core | Procedural sphere with `EnergyShader` (no external model needed) |
+
+---
+
+## Example Workflows
+
+### Make the entity excited while "thinking"
+
+```python
+import requests, time
+
+BASE = "http://localhost:5173/api/control"
+
+def cmd(command, value):
+    requests.post(BASE, json={"command": command, "value": value, "id": str(time.time())})
+
+cmd("setIsThinking", True)
+cmd("setMood", "excited")
+cmd("setIntensity", 1.5)
+# ... do work ...
+cmd("setIsThinking", False)
+cmd("setMood", "calm")
+cmd("setIntensity", 0.5)
+```
+
+### Switch to Energy Core and send a message
+
+```python
+cmd("setActiveCharacterId", "base-sphere")
+cmd("setLastMessage", "Switching to Energy Core mode")
+cmd("setMood", "listening")
+```
+
+---
+
+## How It Works Internally
+
+1. **Vite Plugin** (`vite.config.ts` — `openClawControlPlugin`):
+   - Watches `openclaw-control.json` for file changes.
+   - Exposes `POST /api/control` on the dev server.
+   - Broadcasts valid commands as a custom HMR event `openclaw-command` via the Vite WebSocket.
+
+2. **`useOpenClawControl` hook** (`src/hooks/useOpenClawControl.ts`):
+   - Subscribes to the `openclaw-command` HMR event via `import.meta.hot`.
+   - Applies received commands directly to the Zustand `soulStore`.
+
+3. **`OpenClawControl` component** (`src/OpenClawControl.tsx`):
+   - Alternative polling mechanism: fetches `/openclaw-control.json` every second and applies any new command (identified by `id`).


### PR DESCRIPTION
- README: fix MyCharacter -> DynamicCharacter, add missing features
  (AI chat, voice input/TTS, character selector), add @react-three/drei
  and Three.js to tech list, document all src/ subdirs (hooks, services,
  constants), add env vars section, add character and soul store tables
- SKILL: replace OpenClaw-specific API with standard Python/curl examples,
  document HTTP POST /api/control endpoint (recommended method), keep
  file-write method, add full command/character reference tables, add
  internal architecture section explaining Vite plugin + HMR hook + polling

https://claude.ai/code/session_01VeDVmJ3Z42DaTZRGvefUJZ