### PR TITLE
Add error toast system and consolidate RLS policies

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { GaussianSplatPanel } from './components/GaussianSplatPanel'
 import { MoodDemo } from './components/MoodDemo'
 import { InterfaceChrome } from './components/InterfaceChrome'
 import { UserDiscoveryPanel } from './components/UserDiscoveryPanel'
+import { Toasts } from './components/Toasts'
 import { AuthProvider } from './auth'
 import { useOpenClawControl } from './hooks/useOpenClawControl'
 import { useMultiplayer } from './hooks/useMultiplayer'
@@ -65,6 +66,7 @@ function AppContent() {
                 <GaussianSplatPanel />
                 <UserDiscoveryPanel remoteUsers={remoteUsers} sceneId={currentScene?.id ?? null} />
                 <ChatInterface />
+                <Toasts />
             </div>
         </div>
     )

--- a/src/components/ChatInterface.tsx
+++ b/src/components/ChatInterface.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef, useCallback, memo } from 'react'
 import { useSceneStore } from '../store/sceneStore'
 import { useSoulStore } from '../store/soulStore'
 import { openClawService } from '../services/openClawService'
+import { toast } from '../store/toastStore'
 import { CHARACTERS } from '../constants/characters'
 import type { MessageRole, MoodType } from '../types/database'
 
@@ -254,10 +255,19 @@ export const ChatInterface = () => {
     setInputText('')
 
     const result = await openClawService.sendMessage(trimmed)
-    
+
+    if (result.isError) {
+      // Surface the failure without persisting it as a fake assistant reply
+      toast(result.text, 'error')
+      setMood('sad')
+      setIntensity(0.3)
+      setInputText(trimmed)
+      return
+    }
+
     // Persistent assistant response
     await saveMessage(result.text, 'assistant', result.mood as MoodType, result.intensity)
-    
+
     setMood((result.mood ?? 'calm') as MoodType)
     setIntensity(result.intensity ?? 0.5)
     speakResponse(result.text)
@@ -280,6 +290,11 @@ export const ChatInterface = () => {
     recog.interimResults = false
     recog.onstart = () => { setIsListening(true); setMood('listening'); setIntensity(0.8) }
     recog.onend = () => { setIsListening(false); setMood('calm'); setIntensity(0.5) }
+    recog.onerror = (e: any) => {
+      if (e.error !== 'aborted' && e.error !== 'no-speech') {
+        toast('No se pudo usar el micrófono. Revisa los permisos del navegador.', 'error')
+      }
+    }
     recog.onresult = (e: any) => sendRef.current(e.results[0][0].transcript)
     recognitionRef.current = recog
     return function cleanupSpeechRecognition() {

--- a/src/components/Toasts.tsx
+++ b/src/components/Toasts.tsx
@@ -1,0 +1,92 @@
+import { useEffect } from 'react'
+import { useToastStore, type ToastType } from '../store/toastStore'
+import { useSceneStore } from '../store/sceneStore'
+
+const ACCENTS: Record<ToastType, string> = {
+    error: '#FF7A5C',
+    success: '#8CFFB0',
+    info: '#C9F36A',
+}
+
+const LABELS: Record<ToastType, string> = {
+    error: 'ERROR',
+    success: 'OK',
+    info: 'INFO',
+}
+
+export function Toasts() {
+    const toasts = useToastStore((s) => s.toasts)
+    const removeToast = useToastStore((s) => s.removeToast)
+    const addToast = useToastStore((s) => s.addToast)
+
+    const sceneError = useSceneStore((s) => s.error)
+    const clearError = useSceneStore((s) => s.clearError)
+
+    useEffect(function surfaceSceneErrors() {
+        if (sceneError) {
+            addToast(sceneError, 'error')
+            clearError()
+        }
+    }, [sceneError, addToast, clearError])
+
+    return (
+        <div
+            role="status"
+            aria-live="polite"
+            style={{
+                position: 'absolute',
+                top: 76,
+                right: 18,
+                zIndex: 30,
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'flex-end',
+                gap: 8,
+                pointerEvents: 'none',
+                fontFamily: '"Courier New", monospace',
+            }}
+        >
+            <style>{`
+                @keyframes vea-toast-in {
+                    from { opacity: 0; transform: translateX(16px); }
+                    to { opacity: 1; transform: translateX(0); }
+                }
+            `}</style>
+            {toasts.map((t) => (
+                <div
+                    key={t.id}
+                    onClick={() => removeToast(t.id)}
+                    title="Cerrar"
+                    style={{
+                        pointerEvents: 'auto',
+                        cursor: 'pointer',
+                        maxWidth: 340,
+                        padding: '10px 14px',
+                        borderRadius: 6,
+                        border: '1px solid rgba(140,255,176,0.14)',
+                        borderLeft: `3px solid ${ACCENTS[t.type]}`,
+                        background: 'rgba(10,11,10,0.92)',
+                        backdropFilter: 'blur(14px)',
+                        boxShadow: '0 12px 32px rgba(0,0,0,0.45)',
+                        animation: 'vea-toast-in 0.18s ease-out',
+                    }}
+                >
+                    <div
+                        style={{
+                            fontSize: 9,
+                            letterSpacing: 2,
+                            fontWeight: 700,
+                            color: ACCENTS[t.type],
+                            marginBottom: 3,
+                        }}
+                    >
+                        {LABELS[t.type]}
+                    </div>
+                    <div style={{ fontSize: 12, lineHeight: 1.5, color: '#EAF3DF' }}>
+                        {t.message}
+                    </div>
+                </div>
+            ))}
+        </div>
+    )
+}

--- a/src/services/openClawService.ts
+++ b/src/services/openClawService.ts
@@ -6,6 +6,8 @@ export interface OpenClawResponse {
     text: string;
     mood: string;
     intensity: number;
+    /** True when the request failed and `text` is an error notice, not a real reply. */
+    isError?: boolean;
 }
 
 // System prompt that makes the VEA act as an embodied avatar with emotional awareness
@@ -219,17 +221,11 @@ export const openClawService = {
             persistHistory(userId);
             console.error('[OpenClawService] sendMessage failed:', err);
             const errorResponse: OpenClawResponse = {
-                text: 'Lo siento, hubo un error al conectar con OpenClaw.',
+                text: 'No se pudo conectar con el asistente. Intenta de nuevo.',
                 mood: 'sad',
                 intensity: 0.3,
+                isError: true,
             };
-
-            store.addChatMessage({
-                role: 'assistant',
-                content: errorResponse.text,
-                mood: 'sad',
-                timestamp: Date.now(),
-            });
 
             return errorResponse;
         } finally {

--- a/src/store/toastStore.ts
+++ b/src/store/toastStore.ts
@@ -1,0 +1,46 @@
+import { create } from 'zustand'
+
+// ----------------------------------------------------------------
+// Toast Store — transient user-facing notifications (errors, confirmations).
+// Components render them via <Toasts />; any module can push one with toast().
+// ----------------------------------------------------------------
+
+export type ToastType = 'error' | 'success' | 'info'
+
+export interface Toast {
+    id: number
+    type: ToastType
+    message: string
+}
+
+interface ToastState {
+    toasts: Toast[]
+    addToast: (message: string, type?: ToastType) => void
+    removeToast: (id: number) => void
+}
+
+const TOAST_DURATION_MS = 6000
+const MAX_VISIBLE_TOASTS = 4
+let nextId = 1
+
+export const useToastStore = create<ToastState>()((set) => ({
+    toasts: [],
+
+    addToast: (message, type = 'error') => {
+        const id = nextId++
+        set((s) => ({
+            toasts: [...s.toasts.slice(-(MAX_VISIBLE_TOASTS - 1)), { id, type, message }],
+        }))
+        setTimeout(() => {
+            set((s) => ({ toasts: s.toasts.filter((t) => t.id !== id) }))
+        }, TOAST_DURATION_MS)
+    },
+
+    removeToast: (id) =>
+        set((s) => ({ toasts: s.toasts.filter((t) => t.id !== id) })),
+}))
+
+/** Convenience helper for non-React modules (services, stores). */
+export function toast(message: string, type: ToastType = 'error'): void {
+    useToastStore.getState().addToast(message, type)
+}

--- a/supabase/migrations/010_rls_consolidation.sql
+++ b/supabase/migrations/010_rls_consolidation.sql
@@ -1,0 +1,72 @@
+-- 010_rls_consolidation.sql
+-- Consolidates the RLS policies that exist on the live project as of 2026-07:
+--   * Removes the hand-created "Allow guest and owners ..." policies that
+--     duplicated the owner policies (advisor: multiple_permissive_policies).
+--     The guest zero-UUID escape hatch predates anonymous auth; every client
+--     now signs in via signInAnon and has a real auth.uid().
+--   * Recreates each owner policy with (SELECT auth.uid()) so the function is
+--     evaluated once per statement instead of once per row (advisor:
+--     auth_rls_initplan), and scopes it TO authenticated instead of public.
+--   * Adds the missing covering index for sessions.scene_id (advisor:
+--     unindexed_foreign_keys).
+--
+-- NOTE: migrations 005-009 have not been applied to the live project. If they
+-- are synced later, 009 must also drop messages_owner/scene_objects_owner/
+-- sessions_owner before creating its finer-grained policies.
+
+-- profiles --------------------------------------------------------
+DROP POLICY IF EXISTS profiles_owner ON public.profiles;
+CREATE POLICY profiles_owner ON public.profiles
+    FOR ALL TO authenticated
+    USING ((SELECT auth.uid()) = id)
+    WITH CHECK ((SELECT auth.uid()) = id);
+
+-- scenes ----------------------------------------------------------
+DROP POLICY IF EXISTS scenes_owner ON public.scenes;
+DROP POLICY IF EXISTS "Allow guest and owners to insert scenes" ON public.scenes;
+DROP POLICY IF EXISTS "Allow guest and owners to view scenes" ON public.scenes;
+DROP POLICY IF EXISTS "Allow guest and owners to update scenes" ON public.scenes;
+CREATE POLICY scenes_owner ON public.scenes
+    FOR ALL TO authenticated
+    USING ((SELECT auth.uid()) = user_id)
+    WITH CHECK ((SELECT auth.uid()) = user_id);
+
+-- objects_3d ------------------------------------------------------
+DROP POLICY IF EXISTS objects_3d_owner ON public.objects_3d;
+DROP POLICY IF EXISTS "Allow guest and owners to manage objects_3d" ON public.objects_3d;
+CREATE POLICY objects_3d_owner ON public.objects_3d
+    FOR ALL TO authenticated
+    USING ((SELECT auth.uid()) = user_id)
+    WITH CHECK ((SELECT auth.uid()) = user_id);
+
+-- scene_objects ---------------------------------------------------
+DROP POLICY IF EXISTS scene_objects_owner ON public.scene_objects;
+DROP POLICY IF EXISTS "Allow guest and owners to manage objects" ON public.scene_objects;
+CREATE POLICY scene_objects_owner ON public.scene_objects
+    FOR ALL TO authenticated
+    USING ((SELECT auth.uid()) = user_id)
+    WITH CHECK ((SELECT auth.uid()) = user_id);
+
+-- sessions --------------------------------------------------------
+DROP POLICY IF EXISTS sessions_owner ON public.sessions;
+CREATE POLICY sessions_owner ON public.sessions
+    FOR ALL TO authenticated
+    USING ((SELECT auth.uid()) = user_id)
+    WITH CHECK ((SELECT auth.uid()) = user_id);
+
+-- messages --------------------------------------------------------
+DROP POLICY IF EXISTS messages_owner ON public.messages;
+CREATE POLICY messages_owner ON public.messages
+    FOR ALL TO authenticated
+    USING ((SELECT auth.uid()) = user_id)
+    WITH CHECK ((SELECT auth.uid()) = user_id);
+
+-- avatar_configs ---------------------------------------------------
+DROP POLICY IF EXISTS avatar_configs_owner ON public.avatar_configs;
+CREATE POLICY avatar_configs_owner ON public.avatar_configs
+    FOR ALL TO authenticated
+    USING ((SELECT auth.uid()) = user_id)
+    WITH CHECK ((SELECT auth.uid()) = user_id);
+
+-- Covering index for sessions.scene_id FK -------------------------
+CREATE INDEX IF NOT EXISTS idx_sessions_scene_id ON public.sessions (scene_id);


### PR DESCRIPTION
## What changed

### UI — user-visible error handling
- New toast notification system: `src/store/toastStore.ts` (zustand store, auto-dismiss 6s, max 4 visible, click to close) and `src/components/Toasts.tsx` (themed to match the interface, `aria-live=\"polite\"`), mounted in `App.tsx`.
- `Toasts` watches `sceneStore.error`, so scene/persistence failures that previously died silently in the console are now shown to the user.
- Chat failures are no longer persisted to the `messages` table as fake assistant replies. `openClawService` now flags failures with `isError`; `ChatInterface` shows a toast, sets the avatar mood to sad, and restores the user's input so they can retry.
- Microphone/speech-recognition permission errors also surface a toast.

### DB — `supabase/migrations/010_rls_consolidation.sql`
- Consolidates duplicate permissive RLS policies on `scenes`, `scene_objects`, `objects_3d` (each had two overlapping policies evaluated on every query).
- Removes the hand-created "Allow guest and owners…" policies whose zero-UUID (`00000000-…`) escape hatch let any user read/write rows stamped with that fake user id. Predates anonymous auth; nothing in the code references it.
- Wraps `auth.uid()` in `(SELECT auth.uid())` so it evaluates once per statement instead of once per row, and scopes policies `TO authenticated` (anonymous sign-ins carry the `authenticated` role, so app behavior is unchanged).
- Adds the missing covering index on `sessions.scene_id`.

## Why
Errors were stored in state but never rendered anywhere, chat failures polluted persistent history, and the Supabase performance advisors reported 57 warnings against the live RLS setup.

## Notes for reviewers
- The migration is **already applied to the live project** (via MCP). After applying, the performance advisors report zero warnings (only 8 informational "unused index" notices remain, expected with low traffic).
- Verified end-to-end in the browser: scene create/load works through the new policies (200/201), and the toast renders on real failures.
- `npm run typecheck` and all 13 vitest tests pass.
- Known pre-existing drift (not addressed here): repo migrations 005–009 were never applied to the live project — `messages` is missing the 008 columns (inserts return 400) and the `chat` Edge Function is not deployed. The header of 010 documents the ordering hazard if 009 is synced later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)