### PR TITLE
feat: durable rate limiting + production control channel + build cleanup

### DIFF
--- a/docs/agents/SKILL.md
+++ b/docs/agents/SKILL.md
@@ -68,6 +68,40 @@ send_command("setMood", "excited")
 
 > **Important:** Always include a unique `id` (e.g., a Unix timestamp) with each command. The plugin and the `OpenClawControl` component both use this `id` to avoid re-processing stale commands.
 
+### Method 3 — Production: `POST /functions/v1/control` (deployed app)
+
+Works against the deployed app — no dev server needed. Create an agent token
+in the app (AGENT TOKENS panel, bottom-left) and send commands to the
+Supabase Edge Function:
+
+```bash
+curl -X POST "https://<project-ref>.supabase.co/functions/v1/control" \
+  -H "Content-Type: application/json" \
+  -H "X-Agent-Token: pcvea_..." \
+  -d '{"command": "setMood", "value": "excited", "id": "1"}'
+```
+
+```python
+import requests, time
+
+CONTROL_URL = "https://<project-ref>.supabase.co/functions/v1/control"
+TOKEN = "pcvea_..."  # from the AGENT TOKENS panel — shown once at creation
+
+def cmd(command, value):
+    requests.post(
+        CONTROL_URL,
+        headers={"X-Agent-Token": TOKEN},
+        json={"command": command, "value": value, "id": str(time.time())},
+    ).raise_for_status()
+
+cmd("setIsThinking", True)
+cmd("setMood", "thinking")
+```
+
+Commands and values are identical to Methods 1–2. Each token controls only
+its owner's entity; delivery is a private Realtime channel (`control:{user}`).
+Rate limit: `CONTROL_RATE_LIMIT_PER_MINUTE` (default 60/min per token).
+
 ---
 
 ## Available Commands

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "physicclaw-vea",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "physicclaw-vea",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,13 +27,11 @@
         "@vitest/coverage-v8": "^4.1.5",
         "eslint": "^10.3.0",
         "eslint-plugin-react-hooks": "^7.1.1",
-        "javascript-obfuscator": "^5.4.2",
         "prettier": "^3.8.3",
         "supabase": "^2.98.2",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.59.3",
         "vite": "^7.3.3",
-        "vite-plugin-javascript-obfuscator": "^3.1.0",
         "vitest": "^4.1.5"
       }
     },
@@ -1071,63 +1069,6 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
-    "node_modules/@inversifyjs/common": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@inversifyjs/common/-/common-1.3.3.tgz",
-      "integrity": "sha512-ZH0wrgaJwIo3s9gMCDM2wZoxqrJ6gB97jWXncROfYdqZJv8f3EkqT57faZqN5OTeHWgtziQ6F6g3L8rCvGceCw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@inversifyjs/core": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@inversifyjs/core/-/core-1.3.4.tgz",
-      "integrity": "sha512-gCCmA4BdbHEFwvVZ2elWgHuXZWk6AOu/1frxsS+2fWhjEk2c/IhtypLo5ytSUie1BCiT6i9qnEo4bruBomQsAA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@inversifyjs/common": "1.3.3",
-        "@inversifyjs/reflect-metadata-utils": "0.2.3"
-      }
-    },
-    "node_modules/@inversifyjs/reflect-metadata-utils": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@inversifyjs/reflect-metadata-utils/-/reflect-metadata-utils-0.2.3.tgz",
-      "integrity": "sha512-d3D0o9TeSlvaGM2I24wcNw/Aj3rc4OYvHXOKDC09YEph5fMMiKd6fq1VTQd9tOkDNWvVbw+cnt45Wy9P/t5Lvw==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "reflect-metadata": "0.2.2"
-      }
-    },
-    "node_modules/@javascript-obfuscator/escodegen": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@javascript-obfuscator/escodegen/-/escodegen-2.4.1.tgz",
-      "integrity": "sha512-YrEJJDr4cb+pIQKWzHFoDlDkQzatcrNB6OhAD6iTSwiKwzZUMVdobwbOuLpF4EiLxUj0qP28Xl1saTHYzIPCLg==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "@javascript-obfuscator/estraverse": "^5.3.0",
-        "esprima": "^4.0.1",
-        "esutils": "^2.0.2",
-        "optionator": "^0.8.1"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "optionalDependencies": {
-        "source-map": "~0.6.1"
-      }
-    },
-    "node_modules/@javascript-obfuscator/estraverse": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@javascript-obfuscator/estraverse/-/estraverse-5.4.0.tgz",
-      "integrity": "sha512-CZFX7UZVN9VopGbjTx4UXaXsi9ewoM1buL0kY7j1ftYdSs7p2spv9opxFjHlQ/QGTgh4UqufYqJJ0WKLml7b6w==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1984,13 +1925,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/minimatch": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
-      "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/node": {
       "version": "25.6.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
@@ -2054,13 +1988,6 @@
         "fflate": "~0.8.2",
         "meshoptimizer": "~0.22.0"
       }
-    },
-    "node_modules/@types/validator": {
-      "version": "13.15.10",
-      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.15.10.tgz",
-      "integrity": "sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/webxr": {
       "version": "0.5.24",
@@ -2390,23 +2317,6 @@
         "react": ">= 16.8.0"
       }
     },
-    "node_modules/@vercel/blob": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/@vercel/blob/-/blob-2.3.3.tgz",
-      "integrity": "sha512-MtD7VLo6hU07eHR7bmk5SIMD290q574UaNYTe46qeyRT+hWrCy26CoAqfd7PnIefVXvRehRZBzukxuTO9iGTVg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "async-retry": "^1.3.3",
-        "is-buffer": "^2.0.5",
-        "is-node-process": "^1.2.0",
-        "throttleit": "^2.1.0",
-        "undici": "^6.23.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
     "node_modules/@vitejs/plugin-react": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.2.0.tgz",
@@ -2584,21 +2494,12 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/acorn-import-attributes": {
-      "version": "1.9.5",
-      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
-      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "acorn": "^8"
       }
     },
     "node_modules/acorn-jsx": {
@@ -2609,128 +2510,6 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/ajv": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ajv-formats": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
-      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/anymatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
-      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "normalize-path": "^3.0.0",
-        "picomatch": "^2.0.4"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/anymatch/node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/array-differ": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-3.0.0.tgz",
-      "integrity": "sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/array-union": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/arrify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
-      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/assert": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
-      "integrity": "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "is-nan": "^1.3.2",
-        "object-is": "^1.1.5",
-        "object.assign": "^4.1.4",
-        "util": "^0.12.5"
       }
     },
     "node_modules/assertion-error": {
@@ -2759,50 +2538,6 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
       "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/async-retry": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
-      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "retry": "0.13.1"
-      }
-    },
-    "node_modules/atomically": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/atomically/-/atomically-2.1.1.tgz",
-      "integrity": "sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "stubborn-fs": "^2.0.0",
-        "when-exit": "^2.1.4"
-      }
-    },
-    "node_modules/available-typed-arrays": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
-      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "possible-typed-array-names": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
     },
@@ -2846,17 +2581,6 @@
       "license": "MIT",
       "dependencies": {
         "require-from-string": "^2.0.2"
-      }
-    },
-    "node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
       }
     },
     "node_modules/browserslist": {
@@ -2917,63 +2641,6 @@
         "ieee754": "^1.2.1"
       }
     },
-    "node_modules/buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/call-bind": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
-      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "get-intrinsic": "^1.3.0",
-        "set-function-length": "^1.2.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/call-bound": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
-      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "get-intrinsic": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/camera-controls": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/camera-controls/-/camera-controls-3.1.2.tgz",
@@ -3018,149 +2685,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/chance": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/chance/-/chance-1.1.13.tgz",
-      "integrity": "sha512-V6lQCljcLznE7tUYUM9EOAnnKXbctE6j/rdQkYOHIWbfGQbrzTsAXNW9CdU5XCo4ArXQCj/rb6HgxPlmGJcaUg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/char-regex": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
-      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/charenc": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/class-validator": {
-      "version": "0.14.3",
-      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.3.tgz",
-      "integrity": "sha512-rXXekcjofVN1LTOSw+u4u9WXVEUvNBVjORW154q/IdmYWy1nMbOU9aNtZB0t8m+FJQ9q91jlr2f9CwwUFdFMRA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/validator": "^13.15.3",
-        "libphonenumber-js": "^1.11.1",
-        "validator": "^13.15.20"
-      }
-    },
-    "node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/commander": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/conf": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/conf/-/conf-15.0.2.tgz",
-      "integrity": "sha512-JBSrutapCafTrddF9dH3lc7+T2tBycGF4uPkI4Js+g4vLLEhG6RZcFi3aJd5zntdf5tQxAejJt8dihkoQ/eSJw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^8.17.1",
-        "ajv-formats": "^3.0.1",
-        "atomically": "^2.0.3",
-        "debounce-fn": "^6.0.0",
-        "dot-prop": "^10.0.0",
-        "env-paths": "^3.0.0",
-        "json-schema-typed": "^8.0.1",
-        "semver": "^7.7.2",
-        "uint8array-extras": "^1.5.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/conf/node_modules/env-paths": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
-      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/conf/node_modules/semver": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -3200,37 +2724,11 @@
         "node": ">= 8"
       }
     },
-    "node_modules/crypt": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
-    },
-    "node_modules/debounce-fn": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/debounce-fn/-/debounce-fn-6.0.0.tgz",
-      "integrity": "sha512-rBMW+F2TXryBwB54Q0d8drNEI+TfoS9JpNTAoVpukbWEhjXQq4rySFYLaqXMFXwdv61Zb2OHtj5bviSoimqxRQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mimic-function": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -3257,42 +2755,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/define-data-property": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
-      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/define-properties": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
-      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "define-data-property": "^1.0.1",
-        "has-property-descriptors": "^1.0.0",
-        "object-keys": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/detect-gpu": {
       "version": "5.0.70",
       "resolved": "https://registry.npmjs.org/detect-gpu/-/detect-gpu-5.0.70.tgz",
@@ -3302,42 +2764,11 @@
         "webgl-constants": "^1.1.1"
       }
     },
-    "node_modules/dot-prop": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-10.1.0.tgz",
-      "integrity": "sha512-MVUtAugQMOff5RnBy2d9N31iG0lNwg1qAoAOn7pOK5wf94WIaE3My2p3uwTQuvS2AcqchkcR3bHByjaM0mmi7Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "type-fest": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/draco3d": {
       "version": "1.5.7",
       "resolved": "https://registry.npmjs.org/draco3d/-/draco3d-1.5.7.tgz",
       "integrity": "sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ==",
       "license": "Apache-2.0"
-    },
-    "node_modules/dunder-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
     },
     "node_modules/eciesjs": {
       "version": "0.5.0",
@@ -3364,61 +2795,12 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/env-paths": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-4.0.0.tgz",
-      "integrity": "sha512-pxP8eL2SwwaTRi/KHYwLYXinDs7gL3jxFcBYmEdYfZmZXbaVDvdppd0XBU8qVz03rDfKZMXg1omHCbsJjZrMsw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-safe-filename": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/es-define-property": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-errors": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/es-module-lexer": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
       "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
     },
     "node_modules/esbuild": {
       "version": "0.28.1",
@@ -3559,36 +2941,6 @@
       },
       "peerDependencies": {
         "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
-      }
-    },
-    "node_modules/eslint-scope": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
-      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^5.2.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/eslint/node_modules/ajv": {
@@ -3785,20 +3137,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/esquery": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
@@ -3886,23 +3224,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "BSD-3-Clause"
-    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -3978,22 +3299,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/for-each": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
-      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-callable": "^1.2.7"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -4009,26 +3314,6 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/function-bind": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/generator-function": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
-      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -4037,45 +3322,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/get-intrinsic": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "function-bind": "^1.1.2",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "math-intrinsics": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/glob-parent": {
@@ -4097,19 +3343,6 @@
       "integrity": "sha512-b/ZCF6amfAUb7dJM/MxRs7AetQEahYzJ8PtgfrmEdtw6uyGOr+ZSGtgjFm6mfsBkxJ4d2W7kg+Nlqzqvn3Bc0w==",
       "license": "MIT"
     },
-    "node_modules/gopd": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -4118,61 +3351,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/has-property-descriptors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
-      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-define-property": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-symbols": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/hermes-estree": {
@@ -4260,78 +3438,6 @@
         "node": ">=0.8.19"
       }
     },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/inversify": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/inversify/-/inversify-6.1.4.tgz",
-      "integrity": "sha512-PbxrZH/gTa1fpPEEGAjJQzK8tKMIp5gRg6EFNJlCtzUcycuNdmhv3uk5P8Itm/RIjgHJO16oQRLo9IHzQN51bA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@inversifyjs/common": "1.3.3",
-        "@inversifyjs/core": "1.3.4"
-      }
-    },
-    "node_modules/is-arguments": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
-      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-buffer": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
-      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/is-callable": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -4340,26 +3446,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-generator-function": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
-      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.4",
-        "generator-function": "^2.0.0",
-        "get-proto": "^1.0.1",
-        "has-tostringtag": "^1.0.2",
-        "safe-regex-test": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-glob": {
@@ -4375,83 +3461,11 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-nan": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
-      "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.0",
-        "define-properties": "^1.1.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-node-process": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
-      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/is-promise": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
       "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
       "license": "MIT"
-    },
-    "node_modules/is-regex": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
-      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "gopd": "^1.2.0",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-safe-filename": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-safe-filename/-/is-safe-filename-0.1.1.tgz",
-      "integrity": "sha512-4SrR7AdnY11LHfDKTZY1u6Ga3RuxZdl3YKWWShO5iyuG5h8QS4GD2tOb04peBJ5I7pXbR+CGBNEhTcwK+FzN3g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-typed-array": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
-      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "which-typed-array": "^1.1.16"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -4510,44 +3524,6 @@
         "react": "^19.0.0"
       }
     },
-    "node_modules/javascript-obfuscator": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/javascript-obfuscator/-/javascript-obfuscator-5.4.2.tgz",
-      "integrity": "sha512-VUcjC6IPDuB5vAFVZ7qhGRkyewGWV5p05GuCWr3wwQjAym8icDprqz7B9595pqN6aI8EgyazgogOuac89xIgxw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "@javascript-obfuscator/escodegen": "2.4.1",
-        "@javascript-obfuscator/estraverse": "5.4.0",
-        "@vercel/blob": ">=0.23.0",
-        "acorn": "8.15.0",
-        "acorn-import-attributes": "^1.9.5",
-        "assert": "2.1.0",
-        "chalk": "4.1.2",
-        "chance": "1.1.13",
-        "class-validator": "0.14.3",
-        "commander": "12.1.0",
-        "env-paths": "4.0.0",
-        "eslint-scope": "8.4.0",
-        "eslint-visitor-keys": "4.2.1",
-        "fast-deep-equal": "3.1.3",
-        "inversify": "6.1.4",
-        "js-string-escape": "1.0.1",
-        "md5": "2.3.0",
-        "multimatch": "5.0.0",
-        "process": "0.11.10",
-        "reflect-metadata": "0.2.2",
-        "string-template": "1.0.0",
-        "stringz": "2.1.0",
-        "tslib": "2.8.1"
-      },
-      "bin": {
-        "javascript-obfuscator": "bin/javascript-obfuscator"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/jose": {
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
@@ -4556,16 +3532,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
-      }
-    },
-    "node_modules/js-string-escape": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
-      "integrity": "sha512-Smw4xcfIQ5LVjAOuJCvN/zIodzA/BBSsluuoSykP+lUvScIi4U6RJLfwHet5cxFnCswUjISV8oAXaqaJDY3chg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/js-tokens": {
@@ -4594,20 +3560,6 @@
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/json-schema-typed": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
-      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
-      "dev": true,
-      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -4638,27 +3590,6 @@
       "dependencies": {
         "json-buffer": "3.0.1"
       }
-    },
-    "node_modules/levn": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/libphonenumber-js": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.13.1.tgz",
-      "integrity": "sha512-GEw0GLL7YUUA6nv21IsCvVjtI5Ejn84sjbdfQ9KxdbqEVOk1PZh7xejn01EEiniKw+dBeCfim+8MGeuvVuE2BA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/lie": {
       "version": "3.3.0",
@@ -4756,35 +3687,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/math-intrinsics": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/md5": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
-      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "charenc": "0.0.2",
-        "crypt": "0.0.2",
-        "is-buffer": "~1.1.6"
-      }
-    },
-    "node_modules/md5/node_modules/is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/meshline": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/meshline/-/meshline-3.3.1.tgz",
@@ -4800,74 +3702,12 @@
       "integrity": "sha512-IebiK79sqIy+E4EgOr+CAw+Ke8hAspXKzBd0JdgEmPHiAwmvEj2S4h1rfvo+o/BnfEYd/jAOg5IeeIjzlzSnDg==",
       "license": "MIT"
     },
-    "node_modules/mimic-function": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
-      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/mkdirp": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
-      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/multimatch": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-5.0.0.tgz",
-      "integrity": "sha512-ypMKuglUrZUD99Tk2bUQ+xNQj43lPEfAeX2o9cTteAmShXy2VHDJpuwu1o0xqoKCt9jLVAvwyFKdLTPXKAfJyA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/minimatch": "^3.0.3",
-        "array-differ": "^3.0.0",
-        "array-union": "^2.1.0",
-        "arrify": "^2.0.1",
-        "minimatch": "^3.0.4"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/nanoid": {
       "version": "3.3.12",
@@ -4905,64 +3745,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/normalize-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/object-is": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
-      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.7",
-        "define-properties": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/object-keys": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/object.assign": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
-      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
-        "define-properties": "^1.2.1",
-        "es-object-atoms": "^1.0.0",
-        "has-symbols": "^1.1.0",
-        "object-keys": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/obug": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
@@ -4973,24 +3755,6 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
-    },
-    "node_modules/optionator": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.6",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "word-wrap": "~1.2.3"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
@@ -5070,16 +3834,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/possible-typed-array-names": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
-      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/postcss": {
       "version": "8.5.14",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
@@ -5115,15 +3869,6 @@
       "integrity": "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==",
       "license": "ISC"
     },
-    "node_modules/prelude-ls": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
     "node_modules/prettier": {
       "version": "3.8.3",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
@@ -5138,16 +3883,6 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
-    "node_modules/process": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6.0"
       }
     },
     "node_modules/promise-worker-transferable": {
@@ -5216,13 +3951,6 @@
         }
       }
     },
-    "node_modules/reflect-metadata": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
-      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -5230,16 +3958,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/retry": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
-      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
       }
     },
     "node_modules/rollup": {
@@ -5294,24 +4012,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/safe-regex-test": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
-      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "is-regex": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -5326,24 +4026,6 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/set-function-length": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
-      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "define-data-property": "^1.1.4",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.4",
-        "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/shebang-command": {
@@ -5374,16 +4056,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -5392,17 +4064,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
       }
     },
     "node_modules/stackback": {
@@ -5442,40 +4103,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
       "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/string-template": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/string-template/-/string-template-1.0.0.tgz",
-      "integrity": "sha512-SLqR3GBUXuoPP5MmYtD7ompvXiG87QjT6lzOszyXjTM86Uu7At7vNnt2xgyTLq5o9T4IxTYFyGxcULqpsmsfdg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/stringz": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/stringz/-/stringz-2.1.0.tgz",
-      "integrity": "sha512-KlywLT+MZ+v0IRepfMxRtnSvDCMc3nR1qqCs3m/qIbSOWkNZYT8XHQA31rS3TnKp0c5xjZu3M4GY/2aRKSi/6A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "char-regex": "^1.0.2"
-      }
-    },
-    "node_modules/stubborn-fs": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/stubborn-fs/-/stubborn-fs-2.0.0.tgz",
-      "integrity": "sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "stubborn-utils": "^1.0.1"
-      }
-    },
-    "node_modules/stubborn-utils": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/stubborn-utils/-/stubborn-utils-1.0.2.tgz",
-      "integrity": "sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==",
       "dev": true,
       "license": "MIT"
     },
@@ -5525,19 +4152,6 @@
         "react": ">=17.0"
       }
     },
-    "node_modules/tagged-tag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
-      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/three": {
       "version": "0.182.0",
       "resolved": "https://registry.npmjs.org/three/-/three-0.182.0.tgz",
@@ -5575,19 +4189,6 @@
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.6.10.tgz",
       "integrity": "sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg==",
       "license": "MIT"
-    },
-    "node_modules/throttleit": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
-      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -5719,35 +4320,6 @@
         }
       }
     },
-    "node_modules/type-check": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "prelude-ls": "~1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/type-fest": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.6.0.tgz",
-      "integrity": "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "dependencies": {
-        "tagged-tag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -5784,29 +4356,6 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
-      }
-    },
-    "node_modules/uint8array-extras": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
-      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {
@@ -5865,20 +4414,6 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/util": {
-      "version": "0.12.5",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
-      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "is-arguments": "^1.0.4",
-        "is-generator-function": "^1.0.7",
-        "is-typed-array": "^1.1.3",
-        "which-typed-array": "^1.1.2"
-      }
-    },
     "node_modules/utility-types": {
       "version": "3.11.0",
       "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.11.0.tgz",
@@ -5886,16 +4421,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
-      }
-    },
-    "node_modules/validator": {
-      "version": "13.15.35",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.35.tgz",
-      "integrity": "sha512-TQ5pAGhd5whStmqWvYF4OjQROlmv9SMFVt37qoCBdqRffuuklWYQlCNnEs2ZaIBD1kZRNnikiZOS1eqgkar0iw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.10"
       }
     },
     "node_modules/vite": {
@@ -5971,74 +4496,6 @@
         "yaml": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vite-plugin-javascript-obfuscator": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-javascript-obfuscator/-/vite-plugin-javascript-obfuscator-3.1.0.tgz",
-      "integrity": "sha512-sf4JFlG1iUPl7bLXHGOy+bKWOQUFyXzJFWa+n2S2xMMvyfM+V9R40HhpZoIF1eAjifArM1SF7fbSFIaTuUIbPA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "anymatch": "~3.1.3",
-        "javascript-obfuscator": "^4.1.0"
-      }
-    },
-    "node_modules/vite-plugin-javascript-obfuscator/node_modules/@javascript-obfuscator/escodegen": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@javascript-obfuscator/escodegen/-/escodegen-2.3.1.tgz",
-      "integrity": "sha512-Z0HEAVwwafOume+6LFXirAVZeuEMKWuPzpFbQhCEU9++BMz0IwEa9bmedJ+rMn/IlXRBID9j3gQ0XYAa6jM10g==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "@javascript-obfuscator/estraverse": "^5.3.0",
-        "esprima": "^4.0.1",
-        "esutils": "^2.0.2",
-        "optionator": "^0.8.1"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "optionalDependencies": {
-        "source-map": "~0.6.1"
-      }
-    },
-    "node_modules/vite-plugin-javascript-obfuscator/node_modules/javascript-obfuscator": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/javascript-obfuscator/-/javascript-obfuscator-4.2.2.tgz",
-      "integrity": "sha512-+7oXAUnFCA6vS0omIGHcWpSr67dUBIF7FKGYSXyzxShSLqM6LBgdugWKFl0XrYtGWyJMGfQR5F4LL85iCefkRA==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "@javascript-obfuscator/escodegen": "2.3.1",
-        "@javascript-obfuscator/estraverse": "5.4.0",
-        "acorn": "8.15.0",
-        "assert": "2.1.0",
-        "chalk": "4.1.2",
-        "chance": "1.1.13",
-        "class-validator": "0.14.3",
-        "commander": "12.1.0",
-        "conf": "15.0.2",
-        "eslint-scope": "8.4.0",
-        "eslint-visitor-keys": "4.2.1",
-        "fast-deep-equal": "3.1.3",
-        "inversify": "6.1.4",
-        "js-string-escape": "1.0.1",
-        "md5": "2.3.0",
-        "mkdirp": "3.0.1",
-        "multimatch": "5.0.0",
-        "process": "0.11.10",
-        "reflect-metadata": "0.2.2",
-        "source-map-support": "0.5.21",
-        "string-template": "1.0.0",
-        "stringz": "2.1.0",
-        "tslib": "2.8.1"
-      },
-      "bin": {
-        "javascript-obfuscator": "bin/javascript-obfuscator"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/vitest": {
@@ -6142,13 +4599,6 @@
       "integrity": "sha512-9Z0JcMTFxeE+b2x1LJTdnaT8rT8aEp7MVxkNwoycNmJWwPdzoXzMh0BjJSh/AEFP+KPYZUli814h8bJZFIZ2jA==",
       "license": "MIT"
     },
-    "node_modules/when-exit": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/when-exit/-/when-exit-2.1.5.tgz",
-      "integrity": "sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -6162,28 +4612,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/which-typed-array": {
-      "version": "1.1.20",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
-      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.4",
-        "for-each": "^0.3.5",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/why-is-node-running": {

--- a/package.json
+++ b/package.json
@@ -3,19 +3,19 @@
   "private": true,
   "version": "0.2.0",
   "type": "module",
-    "scripts": {
-        "dev": "vite",
-        "build": "npm run typecheck && vite build",
-        "prebuild": "npm run verify-env",
-        "verify-env": "node ./scripts/verify-env.js",
-        "preview": "vite preview",
-        "typecheck": "tsc --noEmit",
-        "lint": "eslint .",
-        "format": "prettier --write .",
-        "check": "npm run verify-env && npm run typecheck && npm test && npm run lint",
-        "test": "vitest run",
-        "test:watch": "vitest"
-    },
+  "scripts": {
+    "dev": "vite",
+    "build": "npm run typecheck && vite build",
+    "prebuild": "npm run verify-env",
+    "verify-env": "node ./scripts/verify-env.js",
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint .",
+    "format": "prettier --write .",
+    "check": "npm run verify-env && npm run typecheck && npm test && npm run lint",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@types/node": "^25.6.0",
@@ -25,13 +25,11 @@
     "@vitest/coverage-v8": "^4.1.5",
     "eslint": "^10.3.0",
     "eslint-plugin-react-hooks": "^7.1.1",
-    "javascript-obfuscator": "^5.4.2",
     "prettier": "^3.8.3",
     "supabase": "^2.98.2",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.59.3",
     "vite": "^7.3.3",
-    "vite-plugin-javascript-obfuscator": "^3.1.0",
     "vitest": "^4.1.5"
   },
   "dependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { UserDiscoveryPanel } from './components/UserDiscoveryPanel'
 import { Toasts } from './components/Toasts'
 import { AuthProvider } from './auth'
 import { useOpenClawControl } from './hooks/useOpenClawControl'
+import { useProductionControl } from './hooks/useProductionControl'
 import { useMultiplayer } from './hooks/useMultiplayer'
 import { useSoulStore } from './store/soulStore'
 import { useSceneStore } from './store/sceneStore'
@@ -26,6 +27,7 @@ function AppContent() {
     const lowPerformanceMode = useSoulStore((s) => s.lowPerformanceMode)
     const setLowPerformanceMode = useSoulStore((s) => s.setLowPerformanceMode)
     useOpenClawControl()
+    useProductionControl()
 
     useEffect(function initStore() {
         initialize()

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { MoodDemo } from './components/MoodDemo'
 import { InterfaceChrome } from './components/InterfaceChrome'
 import { UserDiscoveryPanel } from './components/UserDiscoveryPanel'
 import { Toasts } from './components/Toasts'
+import { AgentTokenPanel } from './components/AgentTokenPanel'
 import { AuthProvider } from './auth'
 import { useOpenClawControl } from './hooks/useOpenClawControl'
 import { useProductionControl } from './hooks/useProductionControl'
@@ -67,6 +68,7 @@ function AppContent() {
                 <CubeGenerator />
                 <GaussianSplatPanel />
                 <UserDiscoveryPanel remoteUsers={remoteUsers} sceneId={currentScene?.id ?? null} />
+                <AgentTokenPanel />
                 <ChatInterface />
                 <Toasts />
             </div>

--- a/src/components/AgentTokenPanel.tsx
+++ b/src/components/AgentTokenPanel.tsx
@@ -1,0 +1,197 @@
+// ============================================================
+// PhysicClaw-VEA — AgentTokenPanel
+// Manage per-user agent tokens for the production control API.
+// The plaintext secret is displayed exactly once after creation.
+// ============================================================
+import { useCallback, useEffect, useState } from 'react'
+import { agentTokensApi, type AgentToken } from '../lib/agentTokens'
+import { useSoulStore } from '../store/soulStore'
+
+const MONO = '"Courier New", monospace'
+
+export function AgentTokenPanel() {
+    const userId = useSoulStore((s) => s.userId)
+    const [open, setOpen] = useState(false)
+    const [tokens, setTokens] = useState<AgentToken[]>([])
+    const [name, setName] = useState('')
+    const [freshSecret, setFreshSecret] = useState<string | null>(null)
+    const [error, setError] = useState<string | null>(null)
+    const [busy, setBusy] = useState(false)
+
+    const refresh = useCallback(async () => {
+        if (!userId) return
+        try {
+            setTokens(await agentTokensApi.list(userId))
+        } catch (e) {
+            setError(e instanceof Error ? e.message : String(e))
+        }
+    }, [userId])
+
+    useEffect(() => {
+        if (open) void refresh()
+    }, [open, refresh])
+
+    const handleCreate = async () => {
+        if (!userId || !name.trim() || busy) return
+        setBusy(true)
+        setError(null)
+        try {
+            const { secret } = await agentTokensApi.create(userId, name.trim())
+            setFreshSecret(secret)
+            setName('')
+            await refresh()
+        } catch (e) {
+            setError(e instanceof Error ? e.message : String(e))
+        } finally {
+            setBusy(false)
+        }
+    }
+
+    const handleRevoke = async (id: string) => {
+        setError(null)
+        try {
+            await agentTokensApi.revoke(id)
+            await refresh()
+        } catch (e) {
+            setError(e instanceof Error ? e.message : String(e))
+        }
+    }
+
+    if (!userId) return null
+
+    if (!open) {
+        return (
+            <button
+                onClick={() => setOpen(true)}
+                style={{
+                    position: 'absolute', bottom: 16, left: 16, zIndex: 20,
+                    background: 'rgba(10,11,10,0.85)', color: '#8CFFB0',
+                    border: '1px solid rgba(140,255,176,0.25)', borderRadius: 4,
+                    padding: '6px 12px', fontFamily: MONO, fontSize: 10,
+                    letterSpacing: 2, cursor: 'pointer',
+                }}
+            >
+                ⌁ AGENT TOKENS
+            </button>
+        )
+    }
+
+    return (
+        <div
+            style={{
+                position: 'absolute', bottom: 16, left: 16, zIndex: 20,
+                width: 320, maxHeight: '60vh', overflowY: 'auto',
+                background: 'rgba(10,11,10,0.92)', color: '#A9B89A',
+                border: '1px solid rgba(140,255,176,0.25)', borderRadius: 6,
+                padding: 14, fontFamily: MONO,
+            }}
+        >
+            <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 10 }}>
+                <span style={{ fontSize: 10, letterSpacing: 3, color: 'rgba(140,255,176,0.5)' }}>
+                    AGENT TOKENS
+                </span>
+                <button
+                    onClick={() => { setOpen(false); setFreshSecret(null) }}
+                    style={{ background: 'none', border: 'none', color: '#8CFFB0', cursor: 'pointer', fontSize: 12 }}
+                >
+                    ✕
+                </button>
+            </div>
+
+            <div style={{ display: 'flex', gap: 6, marginBottom: 12 }}>
+                <input
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                    placeholder="token name (e.g. dr_botcin)"
+                    maxLength={60}
+                    style={{
+                        flex: 1, background: 'rgba(140,255,176,0.06)', color: '#8CFFB0',
+                        border: '1px solid rgba(140,255,176,0.2)', borderRadius: 3,
+                        padding: '5px 8px', fontFamily: MONO, fontSize: 11,
+                    }}
+                />
+                <button
+                    onClick={() => { void handleCreate() }}
+                    disabled={busy || !name.trim()}
+                    style={{
+                        background: 'rgba(140,255,176,0.12)', color: '#8CFFB0',
+                        border: '1px solid rgba(140,255,176,0.3)', borderRadius: 3,
+                        padding: '5px 10px', fontFamily: MONO, fontSize: 11,
+                        cursor: busy || !name.trim() ? 'default' : 'pointer',
+                        opacity: busy || !name.trim() ? 0.4 : 1,
+                    }}
+                >
+                    CREATE
+                </button>
+            </div>
+
+            {freshSecret && (
+                <div
+                    style={{
+                        border: '1px solid rgba(255,204,0,0.4)', borderRadius: 4,
+                        padding: 8, marginBottom: 12, background: 'rgba(255,204,0,0.05)',
+                    }}
+                >
+                    <div style={{ fontSize: 9, color: '#ffcc00', marginBottom: 6, letterSpacing: 1 }}>
+                        COPY NOW — SHOWN ONLY ONCE
+                    </div>
+                    <code style={{ fontSize: 10, wordBreak: 'break-all', color: '#8CFFB0' }}>
+                        {freshSecret}
+                    </code>
+                    <button
+                        onClick={() => { void navigator.clipboard.writeText(freshSecret) }}
+                        style={{
+                            display: 'block', marginTop: 6, background: 'none',
+                            border: '1px solid rgba(140,255,176,0.3)', borderRadius: 3,
+                            color: '#8CFFB0', fontFamily: MONO, fontSize: 10,
+                            padding: '3px 8px', cursor: 'pointer',
+                        }}
+                    >
+                        COPY
+                    </button>
+                </div>
+            )}
+
+            {error && (
+                <div style={{ fontSize: 10, color: '#ff4444', marginBottom: 10 }}>{error}</div>
+            )}
+
+            {tokens.map((t) => (
+                <div
+                    key={t.id}
+                    style={{
+                        display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+                        padding: '6px 0', borderBottom: '1px solid rgba(140,255,176,0.08)',
+                        opacity: t.revoked ? 0.4 : 1,
+                    }}
+                >
+                    <div>
+                        <div style={{ fontSize: 11, color: '#8CFFB0' }}>{t.name}</div>
+                        <div style={{ fontSize: 9 }}>
+                            {t.revoked
+                                ? 'revoked'
+                                : t.last_used_at
+                                    ? `last used ${new Date(t.last_used_at).toLocaleString()}`
+                                    : 'never used'}
+                        </div>
+                    </div>
+                    {!t.revoked && (
+                        <button
+                            onClick={() => { void handleRevoke(t.id) }}
+                            style={{
+                                background: 'none', border: '1px solid rgba(255,68,68,0.4)',
+                                borderRadius: 3, color: '#ff4444', fontFamily: MONO,
+                                fontSize: 9, padding: '3px 8px', cursor: 'pointer',
+                            }}
+                        >
+                            REVOKE
+                        </button>
+                    )}
+                </div>
+            ))}
+            {tokens.length === 0 && (
+                <div style={{ fontSize: 10, opacity: 0.6 }}>No tokens yet.</div>
+            )}
+        </div>
+    )
+}

--- a/src/components/AgentTokenPanel.tsx
+++ b/src/components/AgentTokenPanel.tsx
@@ -92,6 +92,7 @@ export function AgentTokenPanel() {
                 </span>
                 <button
                     onClick={() => { setOpen(false); setFreshSecret(null) }}
+                    aria-label="Close agent tokens panel"
                     style={{ background: 'none', border: 'none', color: '#8CFFB0', cursor: 'pointer', fontSize: 12 }}
                 >
                     ✕

--- a/src/components/AgentTokenPanel.tsx
+++ b/src/components/AgentTokenPanel.tsx
@@ -22,6 +22,7 @@ export function AgentTokenPanel() {
         if (!userId) return
         try {
             setTokens(await agentTokensApi.list(userId))
+            setError(null)
         } catch (e) {
             setError(e instanceof Error ? e.message : String(e))
         }

--- a/src/components/AgentTokenPanel.tsx
+++ b/src/components/AgentTokenPanel.tsx
@@ -141,7 +141,11 @@ export function AgentTokenPanel() {
                         {freshSecret}
                     </code>
                     <button
-                        onClick={() => { void navigator.clipboard.writeText(freshSecret) }}
+                        onClick={() => {
+                            navigator.clipboard.writeText(freshSecret).catch(() => {
+                                setError('Clipboard unavailable — copy the token manually')
+                            })
+                        }}
                         style={{
                             display: 'block', marginTop: 6, background: 'none',
                             border: '1px solid rgba(140,255,176,0.3)', borderRadius: 3,

--- a/src/hooks/useOpenClawControl.ts
+++ b/src/hooks/useOpenClawControl.ts
@@ -33,7 +33,12 @@ export function useOpenClawControl() {
         }
 
         // ── Production fallback: poll openclaw-control.json ───────────────────
-        const POLL_INTERVAL = Number(import.meta.env.VITE_CONTROL_POLL_MS) || 2000
+        // Opt-in via VITE_CONTROL_POLL_MS: with the Realtime production
+        // control channel (useProductionControl) this legacy polling is
+        // redundant, so deployed builds no longer poll a (usually absent)
+        // file every 2s unless explicitly configured to.
+        const POLL_INTERVAL = Number(import.meta.env.VITE_CONTROL_POLL_MS)
+        if (!Number.isFinite(POLL_INTERVAL) || POLL_INTERVAL <= 0) return
 
         const poll = async () => {
             try {

--- a/src/hooks/useProductionControl.ts
+++ b/src/hooks/useProductionControl.ts
@@ -19,6 +19,10 @@ export function useProductionControl() {
     useEffect(() => {
         if (!userId) return
 
+        // New user (login/logout/account switch) → fresh dedupe state, so a
+        // reused command id from the previous session is not dropped.
+        lastProcessedId.current = undefined
+
         const channel = supabase
             .channel(`control:${userId}`, {
                 config: { private: true, broadcast: { self: false } },

--- a/src/hooks/useProductionControl.ts
+++ b/src/hooks/useProductionControl.ts
@@ -1,0 +1,40 @@
+import { useEffect, useRef } from 'react'
+import { supabase } from '../lib/supabase'
+import { applyCommand, parseControlCommand } from '../lib/clawControl'
+import { useSoulStore } from '../store/soulStore'
+
+/**
+ * useProductionControl
+ *
+ * Subscribes to the private Realtime channel `control:{userId}` where the
+ * `control` Edge Function broadcasts validated agent commands, and applies
+ * them to the soul store through the same path as dev-mode control.
+ * Receiving is enforced server-side by the realtime.messages policy from
+ * migration 012 (owner-only topic).
+ */
+export function useProductionControl() {
+    const userId = useSoulStore((s) => s.userId)
+    const lastProcessedId = useRef<string | undefined>(undefined)
+
+    useEffect(() => {
+        if (!userId) return
+
+        const channel = supabase
+            .channel(`control:${userId}`, {
+                config: { private: true, broadcast: { self: false } },
+            })
+            .on('broadcast', { event: 'command' }, ({ payload }) => {
+                const cmd = parseControlCommand(payload)
+                if (!cmd) return
+                const cmdId = cmd.id ?? JSON.stringify(cmd)
+                if (cmdId === lastProcessedId.current) return
+                applyCommand(cmd)
+                lastProcessedId.current = cmdId
+            })
+            .subscribe()
+
+        return () => {
+            supabase.removeChannel(channel)
+        }
+    }, [userId])
+}

--- a/src/lib/__tests__/agentTokens.test.ts
+++ b/src/lib/__tests__/agentTokens.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest'
+import { generateTokenSecret, sha256Hex } from '../agentTokens'
+
+describe('generateTokenSecret', () => {
+    it('produces pcvea_ + 64 hex chars', () => {
+        const secret = generateTokenSecret()
+        expect(secret).toMatch(/^pcvea_[0-9a-f]{64}$/)
+    })
+
+    it('produces unique values', () => {
+        expect(generateTokenSecret()).not.toEqual(generateTokenSecret())
+    })
+})
+
+describe('sha256Hex', () => {
+    it('matches the known SHA-256 vector for "abc"', async () => {
+        expect(await sha256Hex('abc')).toBe(
+            'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad',
+        )
+    })
+
+    it('returns 64 lowercase hex chars', async () => {
+        const hash = await sha256Hex(generateTokenSecret())
+        expect(hash).toMatch(/^[0-9a-f]{64}$/)
+    })
+})

--- a/src/lib/agentTokens.ts
+++ b/src/lib/agentTokens.ts
@@ -1,0 +1,61 @@
+import { supabase } from './supabase'
+
+export interface AgentToken {
+    id: string
+    name: string
+    created_at: string
+    last_used_at: string | null
+    revoked: boolean
+}
+
+const TOKEN_PREFIX = 'pcvea_'
+const TOKEN_COLUMNS = 'id, name, created_at, last_used_at, revoked'
+
+/** Crypto-random agent token secret. Shown to the user exactly once. */
+export function generateTokenSecret(): string {
+    const bytes = new Uint8Array(32)
+    crypto.getRandomValues(bytes)
+    const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('')
+    return TOKEN_PREFIX + hex
+}
+
+/** Lowercase SHA-256 hex digest (matches what the control function computes). */
+export async function sha256Hex(input: string): Promise<string> {
+    const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(input))
+    return Array.from(new Uint8Array(digest), (b) => b.toString(16).padStart(2, '0')).join('')
+}
+
+export const agentTokensApi = {
+    /** Create a token; returns the row plus the plaintext secret (show once). */
+    async create(userId: string, name: string): Promise<{ token: AgentToken; secret: string }> {
+        const secret = generateTokenSecret()
+        const token_hash = await sha256Hex(secret)
+        const { data, error } = await supabase
+            .from('agent_tokens')
+            .insert({ user_id: userId, name, token_hash })
+            .select(TOKEN_COLUMNS)
+            .single()
+        if (error || !data) {
+            throw new Error(`[Supabase/agentTokensApi.create] ${error?.message ?? 'No data returned'}`)
+        }
+        return { token: data as unknown as AgentToken, secret }
+    },
+
+    async list(userId: string): Promise<AgentToken[]> {
+        const { data, error } = await supabase
+            .from('agent_tokens')
+            .select(TOKEN_COLUMNS)
+            .eq('user_id', userId)
+            .order('created_at', { ascending: false })
+        if (error) throw new Error(`[Supabase/agentTokensApi.list] ${error.message}`)
+        return (data ?? []) as unknown as AgentToken[]
+    },
+
+    async revoke(id: string): Promise<void> {
+        const { error } = await supabase
+            .from('agent_tokens')
+            .update({ revoked: true })
+            .eq('id', id)
+        if (error) throw new Error(`[Supabase/agentTokensApi.revoke] ${error.message}`)
+    },
+}

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,414 @@
+# For detailed configuration reference documentation, visit:
+# https://supabase.com/docs/guides/local-development/cli/config
+# A string used to distinguish different Supabase projects on the same host. Defaults to the
+# working directory name when running `supabase init`.
+project_id = "PhysicClaw-VEA"
+
+[api]
+enabled = true
+# Port to use for the API URL.
+port = 54321
+# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# endpoints. `public` and `graphql_public` schemas are included by default.
+schemas = ["public", "graphql_public"]
+# Extra schemas to add to the search_path of every request.
+extra_search_path = ["public", "extensions"]
+# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# for accidental or malicious requests.
+max_rows = 1000
+# Controls whether new tables, views, sequences and functions created in the `public` schema by
+# `postgres` are reachable through the Data API roles (`anon`, `authenticated`, `service_role`)
+# without explicit GRANTs. When unset, new entities are NOT auto-exposed, matching the new cloud
+# default. Set to `true` to keep the legacy behaviour of auto-exposing new entities; this is
+# deprecated and the field is removed on 2026-10-30 once the always-revoked behaviour is permanent.
+# auto_expose_new_tables = true
+
+[api.tls]
+# Enable HTTPS endpoints locally using a self-signed certificate.
+enabled = false
+# Paths to self-signed certificate pair.
+# cert_path = "../certs/my-cert.pem"
+# key_path = "../certs/my-key.pem"
+
+[db]
+# Port to use for the local database URL.
+port = 54322
+# Port used by db diff command to initialize the shadow database.
+shadow_port = 54320
+# Maximum amount of time to wait for health check when starting the local database.
+health_timeout = "2m"
+# The database major version to use. This has to be the same as your remote database's. Run `SHOW
+# server_version;` on the remote database to check.
+major_version = 17
+
+[db.pooler]
+enabled = false
+# Port to use for the local connection pooler.
+port = 54329
+# Specifies when a server connection can be reused by other clients.
+# Configure one of the supported pooler modes: `transaction`, `session`.
+pool_mode = "transaction"
+# How many server connections to allow per user/database pair.
+default_pool_size = 20
+# Maximum number of client connections allowed.
+max_client_conn = 100
+
+# [db.vault]
+# secret_key = "env(SECRET_VALUE)"
+
+[db.migrations]
+# If disabled, migrations will be skipped during a db push or reset.
+enabled = true
+# Specifies an ordered list of schema files that describe your database.
+# Supports glob patterns relative to supabase directory: "./schemas/*.sql"
+schema_paths = []
+
+[db.seed]
+# If enabled, seeds the database after migrations during a db reset.
+enabled = true
+# Specifies an ordered list of seed files to load during db reset.
+# Supports glob patterns relative to supabase directory: "./seeds/*.sql"
+sql_paths = ["./seed.sql"]
+
+[db.network_restrictions]
+# Enable management of network restrictions.
+enabled = false
+# List of IPv4 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv4 connections. Set empty array to block all IPs.
+allowed_cidrs = ["0.0.0.0/0"]
+# List of IPv6 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv6 connections. Set empty array to block all IPs.
+allowed_cidrs_v6 = ["::/0"]
+
+# Uncomment to reject non-secure connections to the database.
+# [db.ssl_enforcement]
+# enabled = true
+
+[realtime]
+enabled = true
+# Bind realtime via either IPv4 or IPv6. (default: IPv4)
+# ip_version = "IPv6"
+# The maximum length in bytes of HTTP request headers. (default: 4096)
+# max_header_length = 4096
+
+[studio]
+enabled = true
+# Port to use for Supabase Studio.
+port = 54323
+# External URL of the API server that frontend connects to.
+api_url = "http://127.0.0.1"
+# OpenAI API Key to use for Supabase AI in the Supabase Studio.
+openai_api_key = "env(OPENAI_API_KEY)"
+
+# Email testing server. Emails sent with the local dev setup are not actually sent - rather, they
+# are monitored, and you can view the emails that would have been sent from the web interface.
+[local_smtp]
+enabled = true
+# Port to use for the email testing server web interface.
+port = 54324
+# Uncomment to expose additional ports for testing user applications that send emails.
+# smtp_port = 54325
+# pop3_port = 54326
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+[storage]
+enabled = true
+# The maximum file size allowed (e.g. "5MB", "500KB").
+file_size_limit = "50MiB"
+
+# Uncomment to configure local storage buckets
+# [storage.buckets.images]
+# public = false
+# file_size_limit = "50MiB"
+# allowed_mime_types = ["image/png", "image/jpeg"]
+# objects_path = "./images"
+
+# Allow connections via S3 compatible clients
+[storage.s3_protocol]
+enabled = true
+
+# Image transformation API is available to Supabase Pro plan.
+# [storage.image_transformation]
+# enabled = true
+
+# Store analytical data in S3 for running ETL jobs over Iceberg Catalog
+# This feature is only available on the hosted platform.
+[storage.analytics]
+enabled = false
+max_namespaces = 5
+max_tables = 10
+max_catalogs = 2
+
+# Analytics Buckets is available to Supabase Pro plan.
+# [storage.analytics.buckets.my-warehouse]
+
+# Store vector embeddings in S3 for large and durable datasets
+[storage.vector]
+enabled = true
+max_buckets = 10
+max_indexes = 5
+
+# Vector Buckets is available to Supabase Pro plan.
+# [storage.vector.buckets.documents-openai]
+
+[auth]
+enabled = true
+# The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
+# in emails.
+site_url = "http://127.0.0.1:3000"
+# The public URL that Auth serves on. Defaults to the API external URL with `/auth/v1` appended.
+# external_url = ""
+# A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
+additional_redirect_urls = ["https://127.0.0.1:3000"]
+# How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
+jwt_expiry = 3600
+# JWT issuer URL. If not set, defaults to auth.external_url.
+# jwt_issuer = ""
+# Path to JWT signing key. DO NOT commit your signing keys file to git.
+# signing_keys_path = "./signing_keys.json"
+# If disabled, the refresh token will never expire.
+enable_refresh_token_rotation = true
+# Allows refresh tokens to be reused after expiry, up to the specified interval in seconds.
+# Requires enable_refresh_token_rotation = true.
+refresh_token_reuse_interval = 10
+# Allow/disallow new user signups to your project.
+enable_signup = true
+# Allow/disallow anonymous sign-ins to your project.
+enable_anonymous_sign_ins = true
+# Allow/disallow testing manual linking of accounts
+enable_manual_linking = false
+# Passwords shorter than this value will be rejected as weak. Minimum 6, recommended 8 or more.
+minimum_password_length = 6
+# Passwords that do not meet the following requirements will be rejected as weak. Supported values
+# are: `letters_digits`, `lower_upper_letters_digits`, `lower_upper_letters_digits_symbols`
+password_requirements = ""
+
+# Configure passkey sign-ins.
+# [auth.passkey]
+# enabled = false
+
+# Configure WebAuthn relying party settings (required when passkey is enabled).
+# [auth.webauthn]
+# rp_display_name = "Supabase"
+# rp_id = "localhost"
+# rp_origins = ["http://127.0.0.1:3000"]
+
+[auth.rate_limit]
+# Number of emails that can be sent per hour. Requires auth.email.smtp to be enabled.
+email_sent = 2
+# Number of SMS messages that can be sent per hour. Requires auth.sms to be enabled.
+sms_sent = 30
+# Number of anonymous sign-ins that can be made per hour per IP address. Requires enable_anonymous_sign_ins = true.
+anonymous_users = 30
+# Number of sessions that can be refreshed in a 5 minute interval per IP address.
+token_refresh = 150
+# Number of sign up and sign-in requests that can be made in a 5 minute interval per IP address (excludes anonymous users).
+sign_in_sign_ups = 30
+# Number of OTP / Magic link verifications that can be made in a 5 minute interval per IP address.
+token_verifications = 30
+# Number of Web3 logins that can be made in a 5 minute interval per IP address.
+web3 = 30
+
+# Configure one of the supported captcha providers: `hcaptcha`, `turnstile`.
+# [auth.captcha]
+# enabled = true
+# provider = "hcaptcha"
+# secret = ""
+
+[auth.email]
+# Allow/disallow new user signups via email to your project.
+enable_signup = true
+# If enabled, a user will be required to confirm any email change on both the old, and new email
+# addresses. If disabled, only the new email is required to confirm.
+double_confirm_changes = true
+# If enabled, users need to confirm their email address before signing in.
+enable_confirmations = false
+# If enabled, users will need to reauthenticate or have logged in recently to change their password.
+secure_password_change = false
+# Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
+max_frequency = "1s"
+# Number of characters used in the email OTP.
+otp_length = 6
+# Number of seconds before the email OTP expires (defaults to 1 hour).
+otp_expiry = 3600
+
+# Use a production-ready SMTP server
+# [auth.email.smtp]
+# enabled = true
+# host = "smtp.sendgrid.net"
+# port = 587
+# user = "apikey"
+# pass = "env(SENDGRID_API_KEY)"
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+# Uncomment to customize email template
+# [auth.email.template.invite]
+# subject = "You have been invited"
+# content_path = "./supabase/templates/invite.html"
+
+# Uncomment to customize notification email template
+# [auth.email.notification.password_changed]
+# enabled = true
+# subject = "Your password has been changed"
+# content_path = "./templates/password_changed_notification.html"
+
+[auth.sms]
+# Allow/disallow new user signups via SMS to your project.
+enable_signup = false
+# If enabled, users need to confirm their phone number before signing in.
+enable_confirmations = false
+# Template for sending OTP to users
+template = "Your code is {{ `{{ .Code }}` }}"
+# Controls the minimum amount of time that must pass before sending another sms otp.
+max_frequency = "5s"
+
+# Use pre-defined map of phone number to OTP for testing.
+# [auth.sms.test_otp]
+# 4152127777 = "123456"
+
+# Configure logged in session timeouts.
+# [auth.sessions]
+# Force log out after the specified duration.
+# timebox = "24h"
+# Force log out if the user has been inactive longer than the specified duration.
+# inactivity_timeout = "8h"
+
+# This hook runs before a new user is created and allows developers to reject the request based on the incoming user object.
+# [auth.hook.before_user_created]
+# enabled = true
+# uri = "pg-functions://postgres/auth/before-user-created-hook"
+
+# This hook runs before a token is issued and allows you to add additional claims based on the authentication method used.
+# [auth.hook.custom_access_token]
+# enabled = true
+# uri = "pg-functions://<database>/<schema>/<hook_name>"
+
+# Configure one of the supported SMS providers: `twilio`, `twilio_verify`, `messagebird`, `textlocal`, `vonage`.
+[auth.sms.twilio]
+enabled = false
+account_sid = ""
+message_service_sid = ""
+# DO NOT commit your Twilio auth token to git. Use environment variable substitution instead:
+auth_token = "env(SUPABASE_AUTH_SMS_TWILIO_AUTH_TOKEN)"
+
+# Multi-factor-authentication is available to Supabase Pro plan.
+[auth.mfa]
+# Control how many MFA factors can be enrolled at once per user.
+max_enrolled_factors = 10
+
+# Control MFA via App Authenticator (TOTP)
+[auth.mfa.totp]
+enroll_enabled = false
+verify_enabled = false
+
+# Configure MFA via Phone Messaging
+[auth.mfa.phone]
+enroll_enabled = false
+verify_enabled = false
+otp_length = 6
+template = "Your code is {{ `{{ .Code }}` }}"
+max_frequency = "5s"
+
+# Configure MFA via WebAuthn
+# [auth.mfa.web_authn]
+# enroll_enabled = true
+# verify_enabled = true
+
+# Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
+# `discord`, `facebook`, `github`, `gitlab`, `google`, `keycloak`, `linkedin_oidc`, `notion`, `twitch`,
+# `twitter`, `x`, `slack`, `spotify`, `workos`, `zoom`.
+[auth.external.apple]
+enabled = false
+client_id = ""
+# DO NOT commit your OAuth provider secret to git. Use environment variable substitution instead:
+secret = "env(SUPABASE_AUTH_EXTERNAL_APPLE_SECRET)"
+# Overrides the default auth callback URL derived from auth.external_url.
+redirect_uri = ""
+# Overrides the default auth provider URL. Used to support self-hosted gitlab, single-tenant Azure,
+# or any other third-party OIDC providers.
+url = ""
+# If enabled, the nonce check will be skipped. Required for local sign in with Google auth.
+skip_nonce_check = false
+# If enabled, it will allow the user to successfully authenticate when the provider does not return an email address.
+email_optional = false
+
+# Allow Solana wallet holders to sign in to your project via the Sign in with Solana (SIWS, EIP-4361) standard.
+# You can configure "web3" rate limit in the [auth.rate_limit] section and set up [auth.captcha] if self-hosting.
+[auth.web3.solana]
+enabled = false
+
+# Use Firebase Auth as a third-party provider alongside Supabase Auth.
+[auth.third_party.firebase]
+enabled = false
+# project_id = "my-firebase-project"
+
+# Use Auth0 as a third-party provider alongside Supabase Auth.
+[auth.third_party.auth0]
+enabled = false
+# tenant = "my-auth0-tenant"
+# tenant_region = "us"
+
+# Use AWS Cognito (Amplify) as a third-party provider alongside Supabase Auth.
+[auth.third_party.aws_cognito]
+enabled = false
+# user_pool_id = "my-user-pool-id"
+# user_pool_region = "us-east-1"
+
+# Use Clerk as a third-party provider alongside Supabase Auth.
+[auth.third_party.clerk]
+enabled = false
+# Obtain from https://clerk.com/setup/supabase
+# domain = "example.clerk.accounts.dev"
+
+# OAuth server configuration
+[auth.oauth_server]
+# Enable OAuth server functionality
+enabled = false
+# Path for OAuth consent flow UI
+authorization_url_path = "/oauth/consent"
+# Allow dynamic client registration
+allow_dynamic_registration = false
+
+[edge_runtime]
+enabled = true
+# Supported request policies: `oneshot`, `per_worker`.
+# `per_worker` (default) — enables hot reload during local development.
+# `oneshot` — fallback mode if hot reload causes issues (e.g. in large repos or with symlinks).
+policy = "per_worker"
+# Port to attach the Chrome inspector for debugging edge functions.
+inspector_port = 8083
+# The Deno major version to use.
+deno_version = 2
+
+# [edge_runtime.secrets]
+# secret_key = "env(SECRET_VALUE)"
+
+[analytics]
+enabled = true
+port = 54327
+# Configure one of the supported backends: `postgres`, `bigquery`.
+backend = "postgres"
+
+# Experimental features may be deprecated any time
+[experimental]
+# Configures Postgres storage engine to use OrioleDB (S3)
+orioledb_version = ""
+# Configures S3 bucket URL, eg. <bucket_name>.s3-<region>.amazonaws.com
+s3_host = "env(S3_HOST)"
+# Configures S3 bucket region, eg. us-east-1
+s3_region = "env(S3_REGION)"
+# Configures AWS_ACCESS_KEY_ID for S3 bucket
+s3_access_key = "env(S3_ACCESS_KEY)"
+# Configures AWS_SECRET_ACCESS_KEY for S3 bucket
+s3_secret_key = "env(S3_SECRET_KEY)"
+
+# pg-delta is the schema diff engine for db diff / db pull / db remote commit.
+# Set enabled = false to fall back to the legacy migra engine.
+[experimental.pgdelta]
+enabled = true
+# Directory under `supabase/` where declarative files are written.
+# declarative_schema_path = "./database"
+# JSON string passed through to pg-delta SQL formatting.
+# format_options = "{\"keywordCase\":\"upper\",\"indent\":2,\"maxWidth\":80,\"commaStyle\":\"trailing\"}"

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -412,3 +412,6 @@ enabled = true
 # declarative_schema_path = "./database"
 # JSON string passed through to pg-delta SQL formatting.
 # format_options = "{\"keywordCase\":\"upper\",\"indent\":2,\"maxWidth\":80,\"commaStyle\":\"trailing\"}"
+
+[functions.control]
+verify_jwt = false

--- a/supabase/functions/chat/index.ts
+++ b/supabase/functions/chat/index.ts
@@ -36,7 +36,11 @@ function getCorsHeaders(req: Request): Record<string, string> | null {
 }
 
 function getRateLimit(): number {
-  const configuredLimit = Number(Deno.env.get("CHAT_RATE_LIMIT_PER_MINUTE"));
+  // Floor to an integer: the consume_rate_limit RPC declares p_limit as
+  // integer, and a fractional env value would error the RPC on every call.
+  const configuredLimit = Math.floor(
+    Number(Deno.env.get("CHAT_RATE_LIMIT_PER_MINUTE")),
+  );
   return Number.isFinite(configuredLimit) && configuredLimit > 0
     ? configuredLimit
     : DEFAULT_RATE_LIMIT_PER_MINUTE;

--- a/supabase/functions/chat/index.ts
+++ b/supabase/functions/chat/index.ts
@@ -73,6 +73,46 @@ function consumeRateLimit(key: string): { allowed: boolean; retryAfter: number }
   return { allowed: entry.count <= limit, retryAfter };
 }
 
+interface RateLimitResult {
+  allowed: boolean;
+  retryAfter: number;
+}
+
+/**
+ * Durable rate limit via Postgres RPC (shared across isolates).
+ * Returns null on any failure so the caller can fall back to the
+ * in-memory limiter — rate limiting must never take the chat down.
+ */
+async function consumeRateLimitDurable(
+  key: string,
+): Promise<RateLimitResult | null> {
+  const supabaseUrl = Deno.env.get("SUPABASE_URL");
+  const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+  if (!supabaseUrl || !serviceRoleKey) return null;
+
+  try {
+    const serviceClient = createClient(supabaseUrl, serviceRoleKey);
+    const { data, error } = await serviceClient.rpc("consume_rate_limit", {
+      p_key: key,
+      p_limit: getRateLimit(),
+      p_window_ms: RATE_LIMIT_WINDOW_MS,
+    });
+
+    if (error || !Array.isArray(data) || data.length === 0) {
+      console.error("consume_rate_limit RPC failed:", error?.message);
+      return null;
+    }
+
+    return {
+      allowed: Boolean(data[0].allowed),
+      retryAfter: Number(data[0].retry_after_seconds) || 0,
+    };
+  } catch (err) {
+    console.error("consume_rate_limit RPC threw:", err);
+    return null;
+  }
+}
+
 function forbiddenCorsResponse(): Response {
   return new Response(JSON.stringify({ error: "Origin not allowed" }), {
     status: 403,
@@ -156,8 +196,9 @@ Deno.serve(async (req: Request) => {
     return jsonResponse({ error: "Unauthorized" }, 401, corsHeaders);
   }
 
-  const rateLimitKey = `${user.id}:${getClientIp(req)}`;
-  const rateLimitResult = consumeRateLimit(rateLimitKey);
+  const rateLimitKey = `chat:${user.id}:${getClientIp(req)}`;
+  const rateLimitResult = (await consumeRateLimitDurable(rateLimitKey)) ??
+    consumeRateLimit(rateLimitKey);
   if (!rateLimitResult.allowed) {
     return rateLimitResponse(rateLimitResult.retryAfter, corsHeaders);
   }

--- a/supabase/functions/chat/index.ts
+++ b/supabase/functions/chat/index.ts
@@ -46,15 +46,6 @@ function getRateLimit(): number {
     : DEFAULT_RATE_LIMIT_PER_MINUTE;
 }
 
-function getClientIp(req: Request): string {
-  const forwardedFor = req.headers.get("x-forwarded-for");
-  if (forwardedFor) return forwardedFor.split(",")[0].trim();
-
-  return req.headers.get("cf-connecting-ip") ??
-    req.headers.get("x-real-ip") ??
-    "unknown";
-}
-
 function pruneRateLimitMap(now: number): void {
   for (const [key, entry] of rateLimitMap.entries()) {
     if (now > entry.resetAt) rateLimitMap.delete(key);
@@ -124,8 +115,10 @@ async function consumeRateLimitDurable(
       return null;
     }
 
+    // Strict boolean check: anything other than a true boolean from the
+    // RPC (e.g. a coerced string) must NOT be treated as allowed.
     return {
-      allowed: Boolean(data[0].allowed),
+      allowed: data[0].allowed === true,
       retryAfter: Number(data[0].retry_after_seconds) || 0,
     };
   } catch (err) {
@@ -217,7 +210,10 @@ Deno.serve(async (req: Request) => {
     return jsonResponse({ error: "Unauthorized" }, 401, corsHeaders);
   }
 
-  const rateLimitKey = `chat:${user.id}:${getClientIp(req)}`;
+  // Keyed by authenticated uid only: IP headers (x-forwarded-for) are
+  // client-influenceable and would both weaken the limit and blow up the
+  // persisted key cardinality in rate_limits.
+  const rateLimitKey = `chat:${user.id}`;
   const rateLimitResult = (await consumeRateLimitDurable(rateLimitKey)) ??
     consumeRateLimit(rateLimitKey);
   if (!rateLimitResult.allowed) {

--- a/supabase/functions/chat/index.ts
+++ b/supabase/functions/chat/index.ts
@@ -35,6 +35,9 @@ function getCorsHeaders(req: Request): Record<string, string> | null {
   };
 }
 
+// Postgres int4 bound: a larger p_limit would error the RPC on every call.
+const MAX_RATE_LIMIT = 2_147_483_647;
+
 function getRateLimit(): number {
   // Floor to an integer: the consume_rate_limit RPC declares p_limit as
   // integer, and a fractional env value would error the RPC on every call.
@@ -42,7 +45,7 @@ function getRateLimit(): number {
     Number(Deno.env.get("CHAT_RATE_LIMIT_PER_MINUTE")),
   );
   return Number.isFinite(configuredLimit) && configuredLimit > 0
-    ? configuredLimit
+    ? Math.min(configuredLimit, MAX_RATE_LIMIT)
     : DEFAULT_RATE_LIMIT_PER_MINUTE;
 }
 

--- a/supabase/functions/chat/index.ts
+++ b/supabase/functions/chat/index.ts
@@ -78,6 +78,18 @@ interface RateLimitResult {
   retryAfter: number;
 }
 
+// Module scope is reused within an isolate — cache the service client.
+let cachedServiceClient: ReturnType<typeof createClient> | null = null;
+
+function getServiceClient(): ReturnType<typeof createClient> | null {
+  if (cachedServiceClient) return cachedServiceClient;
+  const supabaseUrl = Deno.env.get("SUPABASE_URL");
+  const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+  if (!supabaseUrl || !serviceRoleKey) return null;
+  cachedServiceClient = createClient(supabaseUrl, serviceRoleKey);
+  return cachedServiceClient;
+}
+
 /**
  * Durable rate limit via Postgres RPC (shared across isolates).
  * Returns null on any failure so the caller can fall back to the
@@ -86,12 +98,10 @@ interface RateLimitResult {
 async function consumeRateLimitDurable(
   key: string,
 ): Promise<RateLimitResult | null> {
-  const supabaseUrl = Deno.env.get("SUPABASE_URL");
-  const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
-  if (!supabaseUrl || !serviceRoleKey) return null;
+  const serviceClient = getServiceClient();
+  if (!serviceClient) return null;
 
   try {
-    const serviceClient = createClient(supabaseUrl, serviceRoleKey);
     const { data, error } = await serviceClient.rpc("consume_rate_limit", {
       p_key: key,
       p_limit: getRateLimit(),

--- a/supabase/functions/chat/index.ts
+++ b/supabase/functions/chat/index.ts
@@ -108,8 +108,15 @@ async function consumeRateLimitDurable(
       p_window_ms: RATE_LIMIT_WINDOW_MS,
     });
 
-    if (error || !Array.isArray(data) || data.length === 0) {
-      console.error("consume_rate_limit RPC failed:", error?.message);
+    if (error) {
+      console.error("consume_rate_limit RPC failed:", error.message);
+      return null;
+    }
+    if (!Array.isArray(data) || data.length === 0) {
+      console.error(
+        "consume_rate_limit RPC returned unexpected shape:",
+        JSON.stringify(data),
+      );
       return null;
     }
 

--- a/supabase/functions/control/index.ts
+++ b/supabase/functions/control/index.ts
@@ -40,6 +40,13 @@ function json(
 }
 
 function validateCommand(body: ControlBody): string | null {
+  // `id` is optional but must be a short string when present — otherwise the
+  // client-side Zod schema rejects the whole payload and the command
+  // silently never applies.
+  if (body.id !== undefined &&
+      (typeof body.id !== "string" || body.id.length > 128)) {
+    return "id must be a string of <= 128 chars when provided";
+  }
   switch (body.command) {
     case "setMood":
       return typeof body.value === "string" && VALID_MOODS.includes(body.value)

--- a/supabase/functions/control/index.ts
+++ b/supabase/functions/control/index.ts
@@ -69,6 +69,30 @@ function getControlRateLimit(): number {
     : DEFAULT_CONTROL_RATE_LIMIT_PER_MINUTE;
 }
 
+// In-memory fallback limiter (per isolate) — used only when the durable
+// RPC fails, so a database hiccup degrades to per-isolate limiting
+// instead of no limiting at all.
+const rateLimitMap = new Map<string, { count: number; resetAt: number }>();
+
+function consumeRateLimitLocal(
+  key: string,
+): { allowed: boolean; retryAfter: number } {
+  const now = Date.now();
+  for (const [k, entry] of rateLimitMap.entries()) {
+    if (now > entry.resetAt) rateLimitMap.delete(k);
+  }
+
+  const entry = rateLimitMap.get(key);
+  if (!entry || now > entry.resetAt) {
+    rateLimitMap.set(key, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
+    return { allowed: true, retryAfter: 0 };
+  }
+
+  entry.count += 1;
+  const retryAfter = Math.ceil((entry.resetAt - now) / 1000);
+  return { allowed: entry.count <= getControlRateLimit(), retryAfter };
+}
+
 // Module scope is reused within an isolate — cache the service client.
 let cachedServiceClient: ReturnType<typeof createClient> | null = null;
 
@@ -130,13 +154,23 @@ Deno.serve(async (req: Request) => {
       p_window_ms: RATE_LIMIT_WINDOW_MS,
     },
   );
-  if (!rateError && Array.isArray(rateData) && rateData.length > 0 &&
-      !rateData[0].allowed) {
+  let rate: { allowed: boolean; retryAfter: number };
+  if (!rateError && Array.isArray(rateData) && rateData.length > 0) {
+    rate = {
+      allowed: Boolean(rateData[0].allowed),
+      retryAfter: Number(rateData[0].retry_after_seconds) || 0,
+    };
+  } else {
+    console.error("consume_rate_limit RPC failed:", rateError?.message);
+    rate = consumeRateLimitLocal(`control:${tokenRow.id}`);
+  }
+
+  if (!rate.allowed) {
     return new Response(JSON.stringify({ error: "Too many requests" }), {
       status: 429,
       headers: {
         "Content-Type": "application/json",
-        "Retry-After": String(rateData[0].retry_after_seconds ?? 1),
+        "Retry-After": String(rate.retryAfter || 1),
       },
     });
   }

--- a/supabase/functions/control/index.ts
+++ b/supabase/functions/control/index.ts
@@ -40,9 +40,9 @@ function json(
 }
 
 function validateCommand(body: ControlBody): string | null {
-  // `id` is optional but must be a short string when present — otherwise the
-  // client-side Zod schema rejects the whole payload and the command
-  // silently never applies.
+  // `id` is optional; a non-string id would make the client-side Zod schema
+  // reject the whole payload and the command would silently never apply.
+  // The length cap is server-side hygiene only (not in constraints.ts).
   if (body.id !== undefined &&
       (typeof body.id !== "string" || body.id.length > 128)) {
     return "id must be a string of <= 128 chars when provided";

--- a/supabase/functions/control/index.ts
+++ b/supabase/functions/control/index.ts
@@ -16,10 +16,26 @@ interface ControlBody {
   id?: string;
 }
 
-function json(body: Record<string, unknown>, status: number): Response {
+// Agents are typically server-side callers, but browser-based agents work
+// too: every response carries CORS headers, not just the preflight.
+const CORS_HEADERS: Record<string, string> = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "content-type, x-agent-token",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+
+function json(
+  body: Record<string, unknown>,
+  status: number,
+  extraHeaders: Record<string, string> = {},
+): Response {
   return new Response(JSON.stringify(body), {
     status,
-    headers: { "Content-Type": "application/json" },
+    headers: {
+      ...CORS_HEADERS,
+      "Content-Type": "application/json",
+      ...extraHeaders,
+    },
   });
 }
 
@@ -63,7 +79,11 @@ async function sha256Hex(input: string): Promise<string> {
 }
 
 function getControlRateLimit(): number {
-  const configured = Number(Deno.env.get("CONTROL_RATE_LIMIT_PER_MINUTE"));
+  // Floor to an integer: the consume_rate_limit RPC declares p_limit as
+  // integer, and a fractional env value would error the RPC on every call.
+  const configured = Math.floor(
+    Number(Deno.env.get("CONTROL_RATE_LIMIT_PER_MINUTE")),
+  );
   return Number.isFinite(configured) && configured > 0
     ? configured
     : DEFAULT_CONTROL_RATE_LIMIT_PER_MINUTE;
@@ -107,13 +127,7 @@ function getServiceClient(): ReturnType<typeof createClient> | null {
 
 Deno.serve(async (req: Request) => {
   if (req.method === "OPTIONS") {
-    return new Response("ok", {
-      headers: {
-        "Access-Control-Allow-Origin": "*",
-        "Access-Control-Allow-Headers": "content-type, x-agent-token",
-        "Access-Control-Allow-Methods": "POST, OPTIONS",
-      },
-    });
+    return new Response("ok", { headers: CORS_HEADERS });
   }
   if (req.method !== "POST") return json({ error: "Method not allowed" }, 405);
 
@@ -166,12 +180,8 @@ Deno.serve(async (req: Request) => {
   }
 
   if (!rate.allowed) {
-    return new Response(JSON.stringify({ error: "Too many requests" }), {
-      status: 429,
-      headers: {
-        "Content-Type": "application/json",
-        "Retry-After": String(rate.retryAfter || 1),
-      },
+    return json({ error: "Too many requests" }, 429, {
+      "Retry-After": String(rate.retryAfter || 1),
     });
   }
 

--- a/supabase/functions/control/index.ts
+++ b/supabase/functions/control/index.ts
@@ -1,0 +1,176 @@
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const DEFAULT_CONTROL_RATE_LIMIT_PER_MINUTE = 60;
+
+// Mirrors src/lib/constraints.ts (keep in sync).
+const VALID_MOODS = ["calm", "excited", "thinking", "listening"];
+const INTENSITY_MIN = 0.0;
+const INTENSITY_MAX = 2.0;
+const MESSAGE_MAX_LEN = 500;
+const CHAR_ID_MAX_LEN = 64;
+
+interface ControlBody {
+  command?: string;
+  value?: unknown;
+  id?: string;
+}
+
+function json(body: Record<string, unknown>, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function validateCommand(body: ControlBody): string | null {
+  switch (body.command) {
+    case "setMood":
+      return typeof body.value === "string" && VALID_MOODS.includes(body.value)
+        ? null
+        : `setMood value must be one of: ${VALID_MOODS.join(", ")}`;
+    case "setIsThinking":
+      return typeof body.value === "boolean"
+        ? null
+        : "setIsThinking value must be boolean";
+    case "setIntensity":
+      return typeof body.value === "number" &&
+          body.value >= INTENSITY_MIN && body.value <= INTENSITY_MAX
+        ? null
+        : `setIntensity value must be a number in [${INTENSITY_MIN}, ${INTENSITY_MAX}]`;
+    case "setLastMessage":
+      return typeof body.value === "string" &&
+          body.value.length <= MESSAGE_MAX_LEN
+        ? null
+        : `setLastMessage value must be a string of <= ${MESSAGE_MAX_LEN} chars`;
+    case "setActiveCharacterId":
+      return typeof body.value === "string" &&
+          body.value.length > 0 && body.value.length <= CHAR_ID_MAX_LEN
+        ? null
+        : "setActiveCharacterId value must be a non-empty string";
+    default:
+      return "Unknown command";
+  }
+}
+
+async function sha256Hex(input: string): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(input),
+  );
+  return Array.from(new Uint8Array(digest), (b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function getControlRateLimit(): number {
+  const configured = Number(Deno.env.get("CONTROL_RATE_LIMIT_PER_MINUTE"));
+  return Number.isFinite(configured) && configured > 0
+    ? configured
+    : DEFAULT_CONTROL_RATE_LIMIT_PER_MINUTE;
+}
+
+Deno.serve(async (req: Request) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", {
+      headers: {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Headers": "content-type, x-agent-token",
+        "Access-Control-Allow-Methods": "POST, OPTIONS",
+      },
+    });
+  }
+  if (req.method !== "POST") return json({ error: "Method not allowed" }, 405);
+
+  const supabaseUrl = Deno.env.get("SUPABASE_URL");
+  const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+  if (!supabaseUrl || !serviceRoleKey) {
+    return json({ error: "Server misconfiguration" }, 500);
+  }
+
+  const secret = req.headers.get("x-agent-token");
+  if (!secret || !secret.startsWith("pcvea_")) {
+    return json({ error: "Missing or malformed X-Agent-Token header" }, 401);
+  }
+
+  const serviceClient = createClient(supabaseUrl, serviceRoleKey);
+  const tokenHash = await sha256Hex(secret);
+
+  const { data: tokenRow, error: tokenError } = await serviceClient
+    .from("agent_tokens")
+    .select("id, user_id, revoked")
+    .eq("token_hash", tokenHash)
+    .maybeSingle();
+
+  if (tokenError) {
+    console.error("agent_tokens lookup failed:", tokenError.message);
+    return json({ error: "Server error" }, 500);
+  }
+  if (!tokenRow || tokenRow.revoked) {
+    return json({ error: "Invalid or revoked token" }, 401);
+  }
+
+  // Rate limit per token (shares the durable limiter from migration 011).
+  const { data: rateData, error: rateError } = await serviceClient.rpc(
+    "consume_rate_limit",
+    {
+      p_key: `control:${tokenRow.id}`,
+      p_limit: getControlRateLimit(),
+      p_window_ms: RATE_LIMIT_WINDOW_MS,
+    },
+  );
+  if (!rateError && Array.isArray(rateData) && rateData.length > 0 &&
+      !rateData[0].allowed) {
+    return new Response(JSON.stringify({ error: "Too many requests" }), {
+      status: 429,
+      headers: {
+        "Content-Type": "application/json",
+        "Retry-After": String(rateData[0].retry_after_seconds ?? 1),
+      },
+    });
+  }
+
+  let body: ControlBody;
+  try {
+    body = await req.json();
+  } catch {
+    return json({ error: "Invalid JSON body" }, 400);
+  }
+
+  const validationError = validateCommand(body);
+  if (validationError) return json({ error: validationError }, 400);
+
+  // Broadcast on the private per-user control channel via Realtime REST.
+  const broadcastRes = await fetch(`${supabaseUrl}/realtime/v1/api/broadcast`, {
+    method: "POST",
+    headers: {
+      apikey: serviceRoleKey,
+      Authorization: `Bearer ${serviceRoleKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      messages: [{
+        topic: `control:${tokenRow.user_id}`,
+        event: "command",
+        private: true,
+        payload: { command: body.command, value: body.value, id: body.id },
+      }],
+    }),
+  });
+
+  if (!broadcastRes.ok) {
+    const text = await broadcastRes.text().catch(() => "");
+    console.error(`Realtime broadcast failed ${broadcastRes.status}: ${text}`);
+    return json({ error: "Broadcast failed" }, 502);
+  }
+
+  // Best-effort usage stamp; do not block the response on it.
+  serviceClient
+    .from("agent_tokens")
+    .update({ last_used_at: new Date().toISOString() })
+    .eq("id", tokenRow.id)
+    .then(({ error }) => {
+      if (error) console.error("last_used_at update failed:", error.message);
+    });
+
+  return json({ ok: true }, 200);
+});

--- a/supabase/functions/control/index.ts
+++ b/supabase/functions/control/index.ts
@@ -69,6 +69,18 @@ function getControlRateLimit(): number {
     : DEFAULT_CONTROL_RATE_LIMIT_PER_MINUTE;
 }
 
+// Module scope is reused within an isolate — cache the service client.
+let cachedServiceClient: ReturnType<typeof createClient> | null = null;
+
+function getServiceClient(): ReturnType<typeof createClient> | null {
+  if (cachedServiceClient) return cachedServiceClient;
+  const supabaseUrl = Deno.env.get("SUPABASE_URL");
+  const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+  if (!supabaseUrl || !serviceRoleKey) return null;
+  cachedServiceClient = createClient(supabaseUrl, serviceRoleKey);
+  return cachedServiceClient;
+}
+
 Deno.serve(async (req: Request) => {
   if (req.method === "OPTIONS") {
     return new Response("ok", {
@@ -83,7 +95,8 @@ Deno.serve(async (req: Request) => {
 
   const supabaseUrl = Deno.env.get("SUPABASE_URL");
   const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
-  if (!supabaseUrl || !serviceRoleKey) {
+  const serviceClient = getServiceClient();
+  if (!supabaseUrl || !serviceRoleKey || !serviceClient) {
     return json({ error: "Server misconfiguration" }, 500);
   }
 
@@ -92,7 +105,6 @@ Deno.serve(async (req: Request) => {
     return json({ error: "Missing or malformed X-Agent-Token header" }, 401);
   }
 
-  const serviceClient = createClient(supabaseUrl, serviceRoleKey);
   const tokenHash = await sha256Hex(secret);
 
   const { data: tokenRow, error: tokenError } = await serviceClient

--- a/supabase/functions/control/index.ts
+++ b/supabase/functions/control/index.ts
@@ -63,7 +63,7 @@ function validateCommand(body: ControlBody): string | null {
       return typeof body.value === "string" &&
           body.value.length > 0 && body.value.length <= CHAR_ID_MAX_LEN
         ? null
-        : "setActiveCharacterId value must be a non-empty string";
+        : `setActiveCharacterId value must be a non-empty string of <= ${CHAR_ID_MAX_LEN} chars`;
     default:
       return "Unknown command";
   }
@@ -138,8 +138,10 @@ Deno.serve(async (req: Request) => {
     return json({ error: "Server misconfiguration" }, 500);
   }
 
+  // Full-format check (prefix + 64 hex chars, as issued by the panel) so
+  // garbage never reaches hashing or the DB lookup.
   const secret = req.headers.get("x-agent-token");
-  if (!secret || !secret.startsWith("pcvea_")) {
+  if (!secret || !/^pcvea_[0-9a-f]{64}$/.test(secret)) {
     return json({ error: "Missing or malformed X-Agent-Token header" }, 401);
   }
 
@@ -160,22 +162,31 @@ Deno.serve(async (req: Request) => {
   }
 
   // Rate limit per token (shares the durable limiter from migration 011).
-  const { data: rateData, error: rateError } = await serviceClient.rpc(
-    "consume_rate_limit",
-    {
-      p_key: `control:${tokenRow.id}`,
-      p_limit: getControlRateLimit(),
-      p_window_ms: RATE_LIMIT_WINDOW_MS,
-    },
-  );
-  let rate: { allowed: boolean; retryAfter: number };
-  if (!rateError && Array.isArray(rateData) && rateData.length > 0) {
-    rate = {
-      allowed: Boolean(rateData[0].allowed),
-      retryAfter: Number(rateData[0].retry_after_seconds) || 0,
-    };
-  } else {
-    console.error("consume_rate_limit RPC failed:", rateError?.message);
+  // Any failure — RPC error, thrown fetch, unexpected shape — falls back to
+  // the in-memory limiter; the endpoint never runs unlimited (no fail-open).
+  let rate: { allowed: boolean; retryAfter: number } | null = null;
+  try {
+    const { data: rateData, error: rateError } = await serviceClient.rpc(
+      "consume_rate_limit",
+      {
+        p_key: `control:${tokenRow.id}`,
+        p_limit: getControlRateLimit(),
+        p_window_ms: RATE_LIMIT_WINDOW_MS,
+      },
+    );
+    if (!rateError && Array.isArray(rateData) && rateData.length > 0) {
+      rate = {
+        // Strict boolean check: only a true boolean counts as allowed.
+        allowed: rateData[0].allowed === true,
+        retryAfter: Number(rateData[0].retry_after_seconds) || 0,
+      };
+    } else {
+      console.error("consume_rate_limit RPC failed:", rateError?.message);
+    }
+  } catch (err) {
+    console.error("consume_rate_limit RPC threw:", err);
+  }
+  if (!rate) {
     rate = consumeRateLimitLocal(`control:${tokenRow.id}`);
   }
 

--- a/supabase/migrations/011_rate_limits.sql
+++ b/supabase/migrations/011_rate_limits.sql
@@ -27,7 +27,7 @@ create or replace function public.consume_rate_limit(
 returns table (allowed boolean, retry_after_seconds integer)
 language plpgsql
 security definer
-set search_path = pg_catalog, public
+set search_path = ''
 as $$
 declare
     v_now    timestamptz := now();

--- a/supabase/migrations/011_rate_limits.sql
+++ b/supabase/migrations/011_rate_limits.sql
@@ -31,9 +31,20 @@ set search_path = pg_catalog, public
 as $$
 declare
     v_now    timestamptz := now();
-    v_window interval    := make_interval(secs => p_window_ms / 1000.0);
+    v_window interval;
     v_row    public.rate_limits;
 begin
+    if p_key is null or p_key = '' then
+        raise exception 'consume_rate_limit: p_key must be non-empty';
+    end if;
+    if p_limit is null or p_limit <= 0 then
+        raise exception 'consume_rate_limit: p_limit must be > 0 (got %)', p_limit;
+    end if;
+    if p_window_ms is null or p_window_ms <= 0 then
+        raise exception 'consume_rate_limit: p_window_ms must be > 0 (got %)', p_window_ms;
+    end if;
+    v_window := make_interval(secs => p_window_ms / 1000.0);
+
     -- Opportunistic cleanup: drop keys idle for 2+ windows.
     -- Probabilistic (~1% of calls) so the hot path stays an indexed upsert.
     if random() < 0.01 then

--- a/supabase/migrations/011_rate_limits.sql
+++ b/supabase/migrations/011_rate_limits.sql
@@ -27,7 +27,7 @@ create or replace function public.consume_rate_limit(
 returns table (allowed boolean, retry_after_seconds integer)
 language plpgsql
 security definer
-set search_path = public
+set search_path = pg_catalog, public
 as $$
 declare
     v_now    timestamptz := now();
@@ -35,8 +35,11 @@ declare
     v_row    public.rate_limits;
 begin
     -- Opportunistic cleanup: drop keys idle for 2+ windows.
-    delete from public.rate_limits
-     where window_start < v_now - (v_window * 2);
+    -- Probabilistic (~1% of calls) so the hot path stays an indexed upsert.
+    if random() < 0.01 then
+        delete from public.rate_limits
+         where window_start < v_now - (v_window * 2);
+    end if;
 
     insert into public.rate_limits as rl (key, count, window_start)
     values (p_key, 1, v_now)

--- a/supabase/migrations/011_rate_limits.sql
+++ b/supabase/migrations/011_rate_limits.sql
@@ -1,0 +1,69 @@
+-- 011_rate_limits.sql
+-- Durable rate limiting shared across Edge Function isolates.
+-- Replaces the per-isolate in-memory Map in supabase/functions/chat
+-- (README "Known gaps": in-memory rate limiting is per-isolate and
+-- resets on cold start).
+--
+-- Access model: only the service role touches this table/function.
+-- RLS is enabled with NO policies, so anon/authenticated get nothing;
+-- the function is security definer and EXECUTE is revoked from clients.
+
+create table if not exists public.rate_limits (
+    key          text primary key,
+    count        integer not null default 0,
+    window_start timestamptz not null default now()
+);
+
+create index if not exists rate_limits_window_start_idx
+    on public.rate_limits (window_start);
+
+alter table public.rate_limits enable row level security;
+
+create or replace function public.consume_rate_limit(
+    p_key text,
+    p_limit integer,
+    p_window_ms integer
+)
+returns table (allowed boolean, retry_after_seconds integer)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+    v_now    timestamptz := now();
+    v_window interval    := make_interval(secs => p_window_ms / 1000.0);
+    v_row    public.rate_limits;
+begin
+    -- Opportunistic cleanup: drop keys idle for 2+ windows.
+    delete from public.rate_limits
+     where window_start < v_now - (v_window * 2);
+
+    insert into public.rate_limits as rl (key, count, window_start)
+    values (p_key, 1, v_now)
+    on conflict (key) do update
+        set count = case
+                when rl.window_start < v_now - v_window then 1
+                else rl.count + 1
+            end,
+            window_start = case
+                when rl.window_start < v_now - v_window then v_now
+                else rl.window_start
+            end
+    returning * into v_row;
+
+    allowed := v_row.count <= p_limit;
+    retry_after_seconds := case
+        when allowed then 0
+        else greatest(
+            1,
+            ceil(extract(epoch from (v_row.window_start + v_window - v_now)))::integer
+        )
+    end;
+    return next;
+end;
+$$;
+
+revoke all on function public.consume_rate_limit(text, integer, integer)
+    from public, anon, authenticated;
+grant execute on function public.consume_rate_limit(text, integer, integer)
+    to service_role;

--- a/supabase/migrations/012_agent_tokens.sql
+++ b/supabase/migrations/012_agent_tokens.sql
@@ -1,0 +1,39 @@
+-- 012_agent_tokens.sql
+-- Per-user agent tokens for the production control channel.
+-- The plaintext secret is shown once in the UI; only its SHA-256 hex
+-- lands here. RLS follows the 010 convention: single owner policy,
+-- (select auth.uid()) evaluated per statement, scoped to authenticated.
+
+create table if not exists public.agent_tokens (
+    id           uuid primary key default gen_random_uuid(),
+    user_id      uuid not null references auth.users (id) on delete cascade,
+    name         text not null check (char_length(name) between 1 and 60),
+    token_hash   text not null unique check (token_hash ~ '^[0-9a-f]{64}$'),
+    created_at   timestamptz not null default now(),
+    last_used_at timestamptz,
+    revoked      boolean not null default false
+);
+
+create index if not exists agent_tokens_user_id_idx
+    on public.agent_tokens (user_id);
+
+alter table public.agent_tokens enable row level security;
+
+drop policy if exists agent_tokens_owner on public.agent_tokens;
+create policy agent_tokens_owner on public.agent_tokens
+    for all to authenticated
+    using ((select auth.uid()) = user_id)
+    with check ((select auth.uid()) = user_id);
+
+-- Realtime Authorization for the private control channel.
+-- Owners may RECEIVE broadcast messages on their own topic only.
+-- There is intentionally NO insert policy: clients cannot publish
+-- into control channels; only the control Edge Function (service
+-- role, bypasses RLS) broadcasts.
+drop policy if exists control_channel_receive on realtime.messages;
+create policy control_channel_receive on realtime.messages
+    for select to authenticated
+    using (
+        realtime.messages.extension = 'broadcast'
+        and realtime.topic() = 'control:' || (select auth.uid())::text
+    );

--- a/supabase/migrations/012_agent_tokens.sql
+++ b/supabase/migrations/012_agent_tokens.sql
@@ -19,6 +19,11 @@ create index if not exists agent_tokens_user_id_idx
 
 alter table public.agent_tokens enable row level security;
 
+-- RLS restricts rows, but table privileges must be granted explicitly —
+-- don't rely on the project's "automatically expose new tables" default.
+grant select, insert, update, delete on table public.agent_tokens
+    to authenticated, service_role;
+
 drop policy if exists agent_tokens_owner on public.agent_tokens;
 create policy agent_tokens_owner on public.agent_tokens
     for all to authenticated

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,5 @@
 import { defineConfig, Plugin, ViteDevServer } from 'vite'
 import react from '@vitejs/plugin-react'
-import obfuscatorPlugin from 'vite-plugin-javascript-obfuscator'
 import fs from 'node:fs'
 import path from 'node:path'
 import crypto from 'node:crypto'
@@ -212,23 +211,8 @@ const ALLOWED_PROXY_PATHS = ['/v1/chat/completions', '/v1/models']
 // https://vite.dev/config/
 export default defineConfig({
     plugins: [
-        react(), 
+        react(),
         openClawControlPlugin(),
-        obfuscatorPlugin({
-            include: ['src/**/*.ts', 'src/**/*.tsx'],
-            exclude: [/node_modules/],
-            apply: 'build', // Only obfuscate on production build
-            options: {
-                compact: true,
-                controlFlowFlattening: true,
-                controlFlowFlatteningThreshold: 0.75,
-                numbersToExpressions: true,
-                simplify: true,
-                stringArrayShuffle: true,
-                splitStrings: true,
-                stringArrayThreshold: 0.75
-            }
-        })
     ],
     build: {
         rollupOptions: {


### PR DESCRIPTION
Hey compa! Three upgrades in one PR, each independent in spirit but stacked here so you review once. Merge is 100% your call — happy to split this into separate PRs or drop any part if you prefer.

## 1. Durable rate limiting (migration 011 + chat function)

The README lists the in-memory rate limiter as a known gap (per-isolate, resets on cold start). This adds a `rate_limits` table + an atomic `consume_rate_limit(p_key, p_limit, p_window_ms)` RPC — security definer with empty search_path, argument guards, probabilistic cleanup (~1% of calls), EXECUTE granted to service_role only, no client policies. The `chat` function tries the RPC first (cached service-role client) and falls back to the existing in-memory Map on ANY failure, so rate limiting can never take the chat down. Key is `chat:{user.id}` — uid only, deliberately no IP headers (client-influenceable + unbounded persisted-key cardinality).

## 2. Production control channel (migration 012 + control function + client)

Today external agents can only drive the entity through the Vite dev server. This adds the production path your SKILL.md deserves:

- `agent_tokens` table — users create tokens in a new "AGENT TOKENS" panel (bottom-left); the `pcvea_…` secret is shown exactly once, only its SHA-256 lands in the DB. Owner-scoped RLS following your migration-010 convention.
- New `control` Edge Function: `X-Agent-Token` auth (full format check) → same command validation as `src/lib/constraints.ts` → broadcast on a **private** Realtime channel `control:{user_id}`. A `realtime.messages` policy lets only the owner receive on their topic, and clients can't publish — no spoofing. Existing multiplayer channels are public channels and are untouched by this policy. Per-token rate limit reuses #1 (default 60/min, `CONTROL_RATE_LIMIT_PER_MINUTE`), with in-memory fallback (no fail-open).
- `useProductionControl` hook applies commands through the same `clawControl.applyCommand` path as dev mode. SKILL.md gains a "Method 3 — Production" section (curl + Python examples).
- Behavior note: the legacy `openclaw-control.json` polling in deployed builds is now **opt-in** via `VITE_CONTROL_POLL_MS` — with the Realtime channel it was redundant background polling of a usually-absent file every 2s.

Any agent (Claude, OpenClaw, a cron job) can now give the entity a body with a single authenticated POST against the deployed app.

## 3. Remove production JS obfuscation

Measured on this repo: the obfuscator (controlFlowFlattening 0.75 over all of src/) nearly triples the first-party chunk — **460KB → 166KB (−64%) without it** (vendor chunks were never obfuscated). The repo is public MIT so the source is already readable here; meanwhile obfuscation taxes runtime in a 60fps R3F scene and makes prod stack traces undebuggable.

## Quality gate

Every commit passed `npm run check` (verify-env + typecheck + 17 tests + lint). Before opening this PR the three parts went through a multi-round automated review cycle on my fork (Copilot; 11 rounds total, 19 findings fixed, 1 discarded with justification): DRMD431LU/PhysicClaw-VEA PRs #1–#3 if you want the full audit trail.

**Migration note:** 011 and 012 are additive (new table/function/policies each). 012 touches `realtime.messages` policies — only affects channels joined with `private: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)