### PR TITLE
ci: skip the Claude review when its token is absent

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -25,14 +25,32 @@ jobs:
       issues: read
       id-token: write
 
+    # Without the token the action fails during startup, which turned every
+    # pull request red for a reason that had nothing to do with its contents.
+    # A gate that breaks on missing configuration is noise, not a gate.
+    #
+    # The guard lives in `env` rather than the job-level `if:` because the
+    # `secrets` context is not available there. Add CLAUDE_CODE_OAUTH_TOKEN in
+    # Settings → Secrets and variables → Actions and the review starts running
+    # on its own; no further edit needed here.
+    env:
+      HAS_CLAUDE_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' }}
+
     steps:
       - name: Checkout repository
+        if: env.HAS_CLAUDE_TOKEN == 'true'
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
+      - name: Report that the review was skipped
+        if: env.HAS_CLAUDE_TOKEN != 'true'
+        run: |
+          echo "::notice title=Claude review skipped::CLAUDE_CODE_OAUTH_TOKEN is not set, so the automated review did not run."
+
       - name: Run Claude Code Review
         id: claude-review
+        if: env.HAS_CLAUDE_TOKEN == 'true'
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## The problem

`claude-review` fails on **every** pull request, and has nothing to do
with the code being reviewed. `CLAUDE_CODE_OAUTH_TOKEN` is not
configured, so `claude-code-action` fails during startup.

A check that is always red trains everyone to ignore it, and a gate that
is ignored is worse than no gate at all.

## The fix

Guard the steps on the secret being present, and print a notice when it
is not. The sibling workflow `claude.yml` already survives this way — it
carries an `if:` and reports *skipped* rather than failing, which is why
it has never gone red.

The guard lives in `env` rather than the job-level `if:` because the
`secrets` context is not available there.

## Turning the review back on

Add `CLAUDE_CODE_OAUTH_TOKEN` under **Settings → Secrets and variables →
Actions**. The review then runs by itself — this file needs no further
edit. Two ways to get the token:

- run `/install-github-app` in an interactive Claude Code session, which
  installs the app and configures the secret for you; or
- run `claude setup-token` to mint a long-lived token and paste it in.

## Why not just delete the workflow

Because the capability is worth keeping and the guard costs three lines.
Deleting it would also mean re-adding it later from scratch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
